### PR TITLE
[DEV-55][RFC] Refactor/Auth State in Toolbox

### DIFF
--- a/documentation/docs/modules/authentication.md
+++ b/documentation/docs/modules/authentication.md
@@ -26,6 +26,7 @@ ones to Heroku or AWS depending on what you use.
 ```title=".env"
 REACT_APP_CLIENT_ID=<ClientId>
 REACT_APP_DOMAIN=<Domain>
+REACT_APP_AUDIENCE=<Audience> // optional option - default to 'orfium'
 ```
 
 ### 2. AuthenticationProvider

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@auth0/auth0-react": "^1.10.1",
     "axios": "^0.21.4",
     "axios-mock-adapter": "^1.19.0",
+    "jwt-decode": "^3.1.2",
     "react-router-dom": "^5.3.1"
   },
   "devDependencies": {

--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 
 import { orfiumBaseInstance } from '../request';
 import { AuthenticationProvider, useAuthentication } from './context';
+import { config } from './config';
+import { authStates, AuthStates } from './types';
 
 /*
  * The component that uses the AuthenticationProvider.
@@ -19,46 +21,83 @@ const Authentication: React.FunctionComponent = ({ children }) => {
  * This is the main component that is wrapped on the authentication.
  */
 const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently, user } = useAuthentication();
-  const [systemLoading, setSystemLoading] = useState(true);
+  const { isLoading, isAuthenticated, loginWithRedirect, getAccessTokenSilently } =
+    useAuthentication();
+  const [state, setState] = useState<AuthStates>(authStates.ANONYMOUS);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated && loginWithRedirect) {
+      setState(authStates.ANONYMOUS);
+      loginWithRedirect();
+    } else if (isLoading) {
+      setState(authStates.AUTHENTICATING);
+    } else {
+      setState(authStates.AUTHENTICATED);
+    }
+  }, [isAuthenticated, isLoading]);
 
   // @TODO all this should be inside toolbox wrapper
   useEffect(() => {
-    if (getAccessTokenSilently) {
+    if (getAccessTokenSilently && state === authStates.AUTHENTICATED) {
+      setState(authStates.AUTHORIZING);
       (async () => {
         // @TODO in the future we must define the org_id
         const { token, decodedToken } = await getAccessTokenSilently();
-        // @TODO product code
+
         orfiumBaseInstance.setToken(`Bearer ${token}`);
         const requestInstance = orfiumBaseInstance.createRequest({
           method: 'get',
-          url: '/memberships',
+          url: '/memberships/',
+          params: Boolean(config.productCode) ? { product_code: config.productCode } : undefined,
         });
         const data = await requestInstance.request();
 
+        console.log(data);
         // if token with organization exists do not continue
         if (!decodedToken?.org_id) {
-          // updateSelectedOrganizationId(data[0].org_id)
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          const { token: orgToken } = await getAccessTokenSilently({
-            organization: data[0].org_id,
-            ignoreCache: true,
-          });
-          // @TODO if no organization then show message
-        }
+          if (data.length) {
+            // updateSelectedOrganizationId(data[0].org_id)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            const { token: orgToken } = await getAccessTokenSilently({
+              organization: data[0].org_id,
+              ignoreCache: true,
+            });
 
-        // set false at all times
-        setSystemLoading(false);
+            orfiumBaseInstance.setToken(`Bearer ${orgToken}`);
+
+            setState(authStates.AUTHORIZED);
+          } else {
+            setState(authStates.UNAUTHORIZED);
+          }
+        }
       })();
     }
-  }, [getAccessTokenSilently]);
+  }, [getAccessTokenSilently, state]);
 
   // we need to define `Allowed Callback URLs` and `Allowed Web Origins` on auth0
   // http://localhost:3000/
   // when loading is true before navigation this is not showing anymore
-  if (systemLoading || isLoading || !isAuthenticated) {
+  if (state !== authStates.AUTHORIZED && state !== authStates.UNAUTHORIZED) {
     return <div>Loading...</div>;
+  }
+
+  if (state === authStates.UNAUTHORIZED) {
+    return (
+      <div
+        style={{
+          width: '100vw',
+          height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <h1>You don't have access to this Product.</h1>
+        <h3> Go back or contact your administrator for more information.</h3>
+      </div>
+    );
   }
 
   return <>{children}</>;

--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+
+import { orfiumBaseInstance } from '../request';
+import { AuthenticationProvider, useAuthentication } from './context';
+
+/*
+ * The component that uses the AuthenticationProvider.
+ * All the logic is on the Authentication
+ */
+const Authentication: React.FunctionComponent = ({ children }) => {
+  return (
+    <AuthenticationProvider>
+      <AuthenticationWrapper>{children}</AuthenticationWrapper>
+    </AuthenticationProvider>
+  );
+};
+
+/*
+ * This is the main component that is wrapped on the authentication.
+ */
+const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
+  const { isLoading, isAuthenticated, getAccessTokenSilently, user } = useAuthentication();
+  const [systemLoading, setSystemLoading] = useState(true);
+
+  // @TODO all this should be inside toolbox wrapper
+  useEffect(() => {
+    if (getAccessTokenSilently) {
+      (async () => {
+        // @TODO in the future we must define the org_id
+        const { token, decodedToken } = await getAccessTokenSilently();
+        // @TODO product code
+        orfiumBaseInstance.setToken(`Bearer ${token}`);
+        const requestInstance = orfiumBaseInstance.createRequest({
+          method: 'get',
+          url: '/memberships',
+        });
+        const data = await requestInstance.request();
+
+        // if token with organization exists do not continue
+        if (!decodedToken?.org_id) {
+          // updateSelectedOrganizationId(data[0].org_id)
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          const { token: orgToken } = await getAccessTokenSilently({
+            organization: data[0].org_id,
+            ignoreCache: true,
+          });
+          // @TODO if no organization then show message
+        }
+
+        // set false at all times
+        setSystemLoading(false);
+      })();
+    }
+  }, [getAccessTokenSilently]);
+
+  // we need to define `Allowed Callback URLs` and `Allowed Web Origins` on auth0
+  // http://localhost:3000/
+  // when loading is true before navigation this is not showing anymore
+  if (systemLoading || isLoading || !isAuthenticated) {
+    return <div>Loading...</div>;
+  }
+
+  return <>{children}</>;
+};
+
+export default Authentication;

--- a/src/authentication/authentication.test.tsx
+++ b/src/authentication/authentication.test.tsx
@@ -2,7 +2,7 @@ import * as auth from '@auth0/auth0-react';
 import { cleanup, render } from '@testing-library/react';
 import React from 'react';
 
-import { AuthenticationProvider, useAuthentication } from './context';
+import { Authentication as AuthenticationProvider, useAuthentication } from './index';
 
 jest.spyOn(auth, 'Auth0Provider').mockImplementation(({ children }) => <div>{children}</div>);
 
@@ -22,10 +22,13 @@ describe('Authorization: ', () => {
     cleanup();
   });
   it('renders without crashing', () => {
+    const getAccessTokenSilentlyFun = jest.fn();
+
     // @ts-ignore
     jest.spyOn(auth, 'useAuth0').mockImplementation(() => ({
       isAuthenticated: true,
       isLoading: false,
+      getAccessTokenSilently: getAccessTokenSilentlyFun,
     }));
 
     render(
@@ -36,10 +39,12 @@ describe('Authorization: ', () => {
   });
 
   it('renders the test component', () => {
+    const getAccessTokenSilentlyFun = jest.fn();
     // @ts-ignore
     jest.spyOn(auth, 'useAuth0').mockImplementation(() => ({
       isAuthenticated: true,
       isLoading: false,
+      getAccessTokenSilently: getAccessTokenSilentlyFun,
     }));
 
     const { getByTestId } = render(
@@ -53,10 +58,13 @@ describe('Authorization: ', () => {
 
   it('redirects to login if not authenticated', () => {
     const loginWithRedirectFun = jest.fn();
+    const getAccessTokenSilentlyFun = jest.fn();
+
     // @ts-ignore
     jest.spyOn(auth, 'useAuth0').mockImplementation(() => ({
       isAuthenticated: false,
       isLoading: false,
+      getAccessTokenSilently: getAccessTokenSilentlyFun,
       loginWithRedirect: loginWithRedirectFun,
     }));
 
@@ -71,10 +79,13 @@ describe('Authorization: ', () => {
   });
 
   it('renders the loading while its authenticating', () => {
+    const getAccessTokenSilentlyFun = jest.fn();
+
     // @ts-ignore
     jest.spyOn(auth, 'useAuth0').mockImplementation(() => ({
       isAuthenticated: false,
       isLoading: true,
+      getAccessTokenSilently: getAccessTokenSilentlyFun,
     }));
 
     const { getByTestId } = render(

--- a/src/authentication/config.ts
+++ b/src/authentication/config.ts
@@ -2,4 +2,5 @@ export const config = {
   domain: process.env.REACT_APP_DOMAIN,
   clientId: process.env.REACT_APP_CLIENT_ID,
   audience: process.env.REACT_APP_AUDIENCE,
+  productCode: process.env.REACT_APP_PRODUCT_CODE,
 };

--- a/src/authentication/config.ts
+++ b/src/authentication/config.ts
@@ -1,4 +1,5 @@
 export const config = {
   domain: process.env.REACT_APP_DOMAIN,
   clientId: process.env.REACT_APP_CLIENT_ID,
+  audience: process.env.REACT_APP_AUDIENCE,
 };

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -1,5 +1,6 @@
 import { Auth0Provider, useAuth0 } from '@auth0/auth0-react';
 import { Auth0ProviderOptions } from '@auth0/auth0-react/dist/auth0-provider';
+import jwt_decode from 'jwt-decode';
 import React, { createContext, useEffect } from 'react';
 
 import { config } from './config';
@@ -12,10 +13,12 @@ const onRedirectCallback = () => {
 const providerConfig: Auth0ProviderOptions = {
   domain: config.domain || '',
   clientId: config.clientId || '',
+  audience: config.audience || 'orfium',
   redirectUri: window.location.origin,
   onRedirectCallback,
   useRefreshTokens: true,
-  cacheLocation: 'memory',
+  // this way we persist the token to not refetch on reload - https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options
+  cacheLocation: 'localstorage',
 };
 
 const AuthenticationContext = createContext<AuthenticationContextProps>({
@@ -25,8 +28,21 @@ const AuthenticationContext = createContext<AuthenticationContextProps>({
 });
 
 const Provider: React.FC = ({ children }) => {
-  const { isAuthenticated, isLoading, loginWithRedirect, logout, getAccessTokenSilently, user } =
-    useAuth0();
+  const {
+    isAuthenticated,
+    isLoading,
+    loginWithRedirect,
+    logout,
+    getAccessTokenSilently: getAccessTokenSilentlyAuth0,
+    user,
+  } = useAuth0();
+
+  const getAccessTokenSilently = async () => {
+    const token = await getAccessTokenSilentlyAuth0();
+    const decodedToken = jwt_decode<Record<string, unknown>>(token);
+
+    return { token, decodedToken };
+  };
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -1,10 +1,16 @@
 import { Auth0Provider, useAuth0 } from '@auth0/auth0-react';
 import { Auth0ProviderOptions } from '@auth0/auth0-react/dist/auth0-provider';
 import jwt_decode from 'jwt-decode';
-import React, { createContext, useEffect } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 
 import { config } from './config';
-import { AuthenticationContextProps, AuthenticationProviderProps } from './types';
+import {
+  AuthenticationContextProps,
+  AuthenticationProviderProps,
+  authStates,
+  AuthStates,
+} from './types';
+import { orfiumBaseInstance } from '../request';
 
 const onRedirectCallback = () => {
   return window.location.pathname;
@@ -43,12 +49,6 @@ const Provider: React.FC = ({ children }) => {
 
     return { token, decodedToken };
   };
-
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      loginWithRedirect();
-    }
-  }, [isLoading, isAuthenticated]);
 
   return (
     <AuthenticationContext.Provider

--- a/src/authentication/index.ts
+++ b/src/authentication/index.ts
@@ -1,4 +1,5 @@
+import Authentication from './Authentication';
 import { useAuthentication, AuthenticationProvider } from './context';
 
-export { useAuthentication, AuthenticationProvider };
+export { Authentication, useAuthentication, AuthenticationProvider };
 export * from './types';

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -6,7 +6,7 @@ export type AuthenticationContextProps = {
   isLoading: boolean;
   loginWithRedirect?: () => void;
   logout?: () => void;
-  getAccessTokenSilently?: () => Promise<string>;
+  getAccessTokenSilently?: () => Promise<{ token: string; decodedToken: Record<string, unknown> }>;
   user: User | undefined;
 };
 

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -1,6 +1,26 @@
 import { User } from '@auth0/auth0-react';
 import { Auth0ProviderOptions } from '@auth0/auth0-react/dist/auth0-provider';
 
+export const authStates = {
+  ANONYMOUS: 'anonymous',
+  AUTHENTICATING: 'authenticating',
+  AUTHENTICATED: 'authenticated',
+  UNAUTHORIZED: 'unauthorized',
+  AUTHORIZING: 'authorizing',
+  AUTHORIZED: 'authorized',
+} as const;
+
+export const authStatesType = [
+  authStates.ANONYMOUS,
+  authStates.AUTHENTICATING,
+  authStates.AUTHENTICATED,
+  authStates.UNAUTHORIZED,
+  authStates.AUTHORIZING,
+  authStates.AUTHORIZED,
+] as const;
+
+export type AuthStates = typeof authStatesType[number];
+
 export type AuthenticationContextProps = {
   isAuthenticated: boolean;
   isLoading: boolean;

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,4 +1,12 @@
+import { createAPIInstance } from './createAPIInstance';
+
 export * from 'axios';
 export * from './createAPIInstance';
+
+export const orfiumBaseInstance = createAPIInstance({
+  baseUrl: process.env.REACT_APP_ORFIUM_BASE_URL as string,
+  baseHeaders: {},
+});
+
 export { METHODS, RequestProps } from './request';
 export { default as MockRequest } from './mock';

--- a/src/request/request.test.ts
+++ b/src/request/request.test.ts
@@ -74,15 +74,15 @@ describe('Request: ', () => {
   });
 
   it('correctly sets token', async () => {
-    factory.setToken('I am groot');
+    factory.setToken('Bearer I am groot');
 
-    expect(apiInstance.defaults.headers.common.Authorization).toBe('Token I am groot');
+    expect(apiInstance.defaults.headers.common.Authorization).toBe('Bearer I am groot');
   });
 
   it('correctly removes token', async () => {
-    factory.setToken('I am groot');
+    factory.setToken('Bearer I am groot');
 
-    expect(apiInstance.defaults.headers.common.Authorization).toBe('Token I am groot');
+    expect(apiInstance.defaults.headers.common.Authorization).toBe('Bearer I am groot');
 
     factory.deleteToken();
 

--- a/src/request/request.ts
+++ b/src/request/request.ts
@@ -54,7 +54,7 @@ export const setToken =
   (orfiumAxios: AxiosInstance) =>
   (token: string): void => {
     const hasToken = token !== '';
-    orfiumAxios.defaults.headers.common.Authorization = hasToken ? `Token ${token}` : '';
+    orfiumAxios.defaults.headers.common.Authorization = hasToken ? `${token}` : '';
   };
 
 export const deleteToken = (orfiumAxios: AxiosInstance) => (): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4222,6 +4222,11 @@ just-diff@^5.0.1:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-5.0.3.tgz#4c9c514dec5526b25ab977590e3c39a0cf271554"
   integrity sha512-a8p80xcpJ6sdurk5PxDKb4mav9MeKjA3zFKZpCWBIfvg8mznfnmb13MKZvlrwJ+Lhis0wM3uGAzE0ArhFHvIcg==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"


### PR DESCRIPTION
## Description
 
 While working on DEV-55 and after our discussion on business logic inside Toolbox, I noticed that it's not that we are just adding a lot of functionality on toolbox, but we have overlapping states defined in routing and authentication. 
 
 These Auth States will be also a part of Authorization process and maybe more. 
 
 Made a quick and dirty RFC in order to discuss this option.
 
 In general, auth states could be another module, that will be shared inside all of the toolbox modules , but it doesn't have to be exposed to the end user.
 
 It's possible states are: 
```
 export const authStates = {
  ANONYMOUS: 'anonymous',
  AUTHENTICATING: 'authenticating',
  AUTHENTICATED: 'authenticated',
  UNAUTHORIZED: 'unauthorized',
  AUTHORIZING: 'authorizing',
  AUTHORIZED: 'authorized',
} as const;
```

These can be shared also in Routing ( if needed ) and in the Authorization provider ( if needed when implemented ).