### PR TITLE
feat: expose organization store, only the information and not the setters

### DIFF
--- a/documentation/docs/api/interfaces/AxiosPromise.md
+++ b/documentation/docs/api/interfaces/AxiosPromise.md
@@ -1,16 +1,16 @@
 ---
-id: "AxiosPromise"
-title: "Interface: AxiosPromise<T>"
-sidebar_label: "AxiosPromise"
+id: 'AxiosPromise'
+title: 'Interface: AxiosPromise<T>'
+sidebar_label: 'AxiosPromise'
 sidebar_position: 0
 custom_edit_url: null
 ---
 
 ## Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ## Hierarchy
 
@@ -26,7 +26,7 @@ custom_edit_url: null
 
 #### Inherited from
 
-Promise.\_\_@toStringTag@5603
+Promise.\_\_@toStringTag@5622
 
 #### Defined in
 
@@ -42,15 +42,15 @@ Attaches a callback for only the rejection of the Promise.
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type    |
+| :-------- | :------ |
 | `TResult` | `never` |
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `onrejected?` | ``null`` \| (`reason`: `any`) => `TResult` \| `PromiseLike`<`TResult`\> | The callback to execute when the Promise is rejected. |
+| Name          | Type                                                                  | Description                                           |
+| :------------ | :-------------------------------------------------------------------- | :---------------------------------------------------- |
+| `onrejected?` | `null` \| (`reason`: `any`) => `TResult` \| `PromiseLike`<`TResult`\> | The callback to execute when the Promise is rejected. |
 
 #### Returns
 
@@ -66,7 +66,7 @@ Promise.catch
 
 documentation/node_modules/typescript/lib/lib.es5.d.ts:1509
 
-___
+---
 
 ### finally
 
@@ -77,9 +77,9 @@ resolved value cannot be modified from the callback.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `onfinally?` | ``null`` \| () => `void` | The callback to execute when the Promise is settled (fulfilled or rejected). |
+| Name         | Type                   | Description                                                                  |
+| :----------- | :--------------------- | :--------------------------------------------------------------------------- |
+| `onfinally?` | `null` \| () => `void` | The callback to execute when the Promise is settled (fulfilled or rejected). |
 
 #### Returns
 
@@ -95,7 +95,7 @@ Promise.finally
 
 documentation/node_modules/typescript/lib/lib.es2018.promise.d.ts:31
 
-___
+---
 
 ### then
 
@@ -105,17 +105,17 @@ Attaches callbacks for the resolution and/or rejection of the Promise.
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type                                      |
+| :--------- | :---------------------------------------- |
 | `TResult1` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
-| `TResult2` | `never` |
+| `TResult2` | `never`                                   |
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `onfulfilled?` | ``null`` \| (`value`: [`AxiosResponse`](AxiosResponse.md)<`T`\>) => `TResult1` \| `PromiseLike`<`TResult1`\> | The callback to execute when the Promise is resolved. |
-| `onrejected?` | ``null`` \| (`reason`: `any`) => `TResult2` \| `PromiseLike`<`TResult2`\> | The callback to execute when the Promise is rejected. |
+| Name           | Type                                                                                                       | Description                                           |
+| :------------- | :--------------------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
+| `onfulfilled?` | `null` \| (`value`: [`AxiosResponse`](AxiosResponse.md)<`T`\>) => `TResult1` \| `PromiseLike`<`TResult1`\> | The callback to execute when the Promise is resolved. |
+| `onrejected?`  | `null` \| (`reason`: `any`) => `TResult2` \| `PromiseLike`<`TResult2`\>                                    | The callback to execute when the Promise is rejected. |
 
 #### Returns
 

--- a/documentation/docs/api/interfaces/AxiosRequestConfig.md
+++ b/documentation/docs/api/interfaces/AxiosRequestConfig.md
@@ -1,7 +1,7 @@
 ---
-id: "AxiosRequestConfig"
-title: "Interface: AxiosRequestConfig"
-sidebar_label: "AxiosRequestConfig"
+id: 'AxiosRequestConfig'
+title: 'Interface: AxiosRequestConfig'
+sidebar_label: 'AxiosRequestConfig'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -16,7 +16,7 @@ custom_edit_url: null
 
 node_modules/axios/index.d.ts:63
 
-___
+---
 
 ### auth
 
@@ -26,7 +26,7 @@ ___
 
 node_modules/axios/index.d.ts:64
 
-___
+---
 
 ### baseURL
 
@@ -36,7 +36,7 @@ ___
 
 node_modules/axios/index.d.ts:53
 
-___
+---
 
 ### cancelToken
 
@@ -46,7 +46,7 @@ ___
 
 node_modules/axios/index.d.ts:78
 
-___
+---
 
 ### data
 
@@ -56,7 +56,7 @@ ___
 
 node_modules/axios/index.d.ts:59
 
-___
+---
 
 ### decompress
 
@@ -66,7 +66,7 @@ ___
 
 node_modules/axios/index.d.ts:79
 
-___
+---
 
 ### headers
 
@@ -76,7 +76,7 @@ ___
 
 node_modules/axios/index.d.ts:56
 
-___
+---
 
 ### httpAgent
 
@@ -86,7 +86,7 @@ ___
 
 node_modules/axios/index.d.ts:75
 
-___
+---
 
 ### httpsAgent
 
@@ -96,7 +96,7 @@ ___
 
 node_modules/axios/index.d.ts:76
 
-___
+---
 
 ### maxBodyLength
 
@@ -106,7 +106,7 @@ ___
 
 node_modules/axios/index.d.ts:72
 
-___
+---
 
 ### maxContentLength
 
@@ -116,7 +116,7 @@ ___
 
 node_modules/axios/index.d.ts:70
 
-___
+---
 
 ### maxRedirects
 
@@ -126,17 +126,17 @@ ___
 
 node_modules/axios/index.d.ts:73
 
-___
+---
 
 ### method
 
-• `Optional` **method**: [`Method`](../modules.md#method)
+• `Optional` **method**: [`Method`](../modules.md#method-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:52
 
-___
+---
 
 ### params
 
@@ -146,37 +146,37 @@ ___
 
 node_modules/axios/index.d.ts:57
 
-___
+---
 
 ### proxy
 
-• `Optional` **proxy**: ``false`` \| [`AxiosProxyConfig`](AxiosProxyConfig.md)
+• `Optional` **proxy**: `false` \| [`AxiosProxyConfig`](AxiosProxyConfig.md)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:77
 
-___
+---
 
 ### responseType
 
-• `Optional` **responseType**: [`ResponseType`](../modules.md#responsetype)
+• `Optional` **responseType**: [`ResponseType`](../modules.md#responsetype-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:65
 
-___
+---
 
 ### socketPath
 
-• `Optional` **socketPath**: ``null`` \| `string`
+• `Optional` **socketPath**: `null` \| `string`
 
 #### Defined in
 
 node_modules/axios/index.d.ts:74
 
-___
+---
 
 ### timeout
 
@@ -186,7 +186,7 @@ ___
 
 node_modules/axios/index.d.ts:60
 
-___
+---
 
 ### timeoutErrorMessage
 
@@ -196,7 +196,7 @@ ___
 
 node_modules/axios/index.d.ts:61
 
-___
+---
 
 ### transformRequest
 
@@ -206,7 +206,7 @@ ___
 
 node_modules/axios/index.d.ts:54
 
-___
+---
 
 ### transformResponse
 
@@ -216,7 +216,7 @@ ___
 
 node_modules/axios/index.d.ts:55
 
-___
+---
 
 ### transitional
 
@@ -226,7 +226,7 @@ ___
 
 node_modules/axios/index.d.ts:80
 
-___
+---
 
 ### url
 
@@ -236,17 +236,17 @@ ___
 
 node_modules/axios/index.d.ts:51
 
-___
+---
 
 ### validateStatus
 
-• `Optional` **validateStatus**: ``null`` \| (`status`: `number`) => `boolean`
+• `Optional` **validateStatus**: `null` \| (`status`: `number`) => `boolean`
 
 #### Defined in
 
 node_modules/axios/index.d.ts:71
 
-___
+---
 
 ### withCredentials
 
@@ -256,7 +256,7 @@ ___
 
 node_modules/axios/index.d.ts:62
 
-___
+---
 
 ### xsrfCookieName
 
@@ -266,7 +266,7 @@ ___
 
 node_modules/axios/index.d.ts:66
 
-___
+---
 
 ### xsrfHeaderName
 
@@ -284,8 +284,8 @@ node_modules/axios/index.d.ts:67
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name            | Type  |
+| :-------------- | :---- |
 | `progressEvent` | `any` |
 
 #### Returns
@@ -296,7 +296,7 @@ node_modules/axios/index.d.ts:67
 
 node_modules/axios/index.d.ts:69
 
-___
+---
 
 ### onUploadProgress
 
@@ -304,8 +304,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name            | Type  |
+| :-------------- | :---- |
 | `progressEvent` | `any` |
 
 #### Returns
@@ -316,7 +316,7 @@ ___
 
 node_modules/axios/index.d.ts:68
 
-___
+---
 
 ### paramsSerializer
 
@@ -324,8 +324,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type  |
+| :------- | :---- |
 | `params` | `any` |
 
 #### Returns

--- a/documentation/docs/api/interfaces/AxiosStatic.md
+++ b/documentation/docs/api/interfaces/AxiosStatic.md
@@ -1,7 +1,7 @@
 ---
-id: "AxiosStatic"
-title: "Interface: AxiosStatic"
-sidebar_label: "AxiosStatic"
+id: 'AxiosStatic'
+title: 'Interface: AxiosStatic'
+sidebar_label: 'AxiosStatic'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -20,8 +20,8 @@ custom_edit_url: null
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                                          |
+| :------- | :-------------------------------------------- |
 | `config` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -38,9 +38,9 @@ node_modules/axios/index.d.ts:138
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -61,7 +61,7 @@ node_modules/axios/index.d.ts:139
 
 node_modules/axios/index.d.ts:158
 
-___
+---
 
 ### CancelToken
 
@@ -71,7 +71,7 @@ ___
 
 node_modules/axios/index.d.ts:159
 
-___
+---
 
 ### defaults
 
@@ -79,13 +79,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[defaults](AxiosInstance.md#defaults)
+[AxiosInstance](AxiosInstance.md).[defaults](AxiosInstance.md#defaults-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:140
 
-___
+---
 
 ### interceptors
 
@@ -93,14 +93,14 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `request` | [`AxiosInterceptorManager`](AxiosInterceptorManager.md)<[`AxiosRequestConfig`](AxiosRequestConfig.md)\> |
-| `response` | [`AxiosInterceptorManager`](AxiosInterceptorManager.md)<[`AxiosResponse`](AxiosResponse.md)<`any`\>\> |
+| Name       | Type                                                                                                    |
+| :--------- | :------------------------------------------------------------------------------------------------------ |
+| `request`  | [`AxiosInterceptorManager`](AxiosInterceptorManager.md)<[`AxiosRequestConfig`](AxiosRequestConfig.md)\> |
+| `response` | [`AxiosInterceptorManager`](AxiosInterceptorManager.md)<[`AxiosResponse`](AxiosResponse.md)<`any`\>\>   |
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[interceptors](AxiosInstance.md#interceptors)
+[AxiosInstance](AxiosInstance.md).[interceptors](AxiosInstance.md#interceptors-4)
 
 #### Defined in
 
@@ -115,13 +115,13 @@ node_modules/axios/index.d.ts:141
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                       |
+| :------- | :------------------------- |
 | `values` | (`T` \| `Promise`<`T`\>)[] |
 
 #### Returns
@@ -132,7 +132,7 @@ node_modules/axios/index.d.ts:141
 
 node_modules/axios/index.d.ts:161
 
-___
+---
 
 ### create
 
@@ -140,8 +140,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -152,7 +152,7 @@ ___
 
 node_modules/axios/index.d.ts:157
 
-___
+---
 
 ### delete
 
@@ -160,16 +160,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -178,13 +178,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[delete](AxiosInstance.md#delete)
+[AxiosInstance](AxiosInstance.md).[delete](AxiosInstance.md#delete-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:148
 
-___
+---
 
 ### get
 
@@ -192,16 +192,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -210,13 +210,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[get](AxiosInstance.md#get)
+[AxiosInstance](AxiosInstance.md).[get](AxiosInstance.md#get-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:147
 
-___
+---
 
 ### getUri
 
@@ -224,8 +224,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -234,13 +234,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[getUri](AxiosInstance.md#geturi)
+[AxiosInstance](AxiosInstance.md).[getUri](AxiosInstance.md#geturi-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:145
 
-___
+---
 
 ### head
 
@@ -248,16 +248,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -266,13 +266,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[head](AxiosInstance.md#head)
+[AxiosInstance](AxiosInstance.md).[head](AxiosInstance.md#head-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:149
 
-___
+---
 
 ### isAxiosError
 
@@ -280,8 +280,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type  |
+| :-------- | :---- |
 | `payload` | `any` |
 
 #### Returns
@@ -292,7 +292,7 @@ payload is AxiosError<any\>
 
 node_modules/axios/index.d.ts:163
 
-___
+---
 
 ### isCancel
 
@@ -300,8 +300,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type  |
+| :------ | :---- |
 | `value` | `any` |
 
 #### Returns
@@ -312,7 +312,7 @@ ___
 
 node_modules/axios/index.d.ts:160
 
-___
+---
 
 ### options
 
@@ -320,16 +320,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -338,13 +338,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[options](AxiosInstance.md#options)
+[AxiosInstance](AxiosInstance.md).[options](AxiosInstance.md#options-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:150
 
-___
+---
 
 ### patch
 
@@ -352,17 +352,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
-| `data?` | `any` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
+| `data?`   | `any`                                         |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -371,13 +371,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[patch](AxiosInstance.md#patch)
+[AxiosInstance](AxiosInstance.md).[patch](AxiosInstance.md#patch-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:153
 
-___
+---
 
 ### post
 
@@ -385,17 +385,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
-| `data?` | `any` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
+| `data?`   | `any`                                         |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -404,13 +404,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[post](AxiosInstance.md#post)
+[AxiosInstance](AxiosInstance.md).[post](AxiosInstance.md#post-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:151
 
-___
+---
 
 ### put
 
@@ -418,17 +418,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `url` | `string` |
-| `data?` | `any` |
+| Name      | Type                                          |
+| :-------- | :-------------------------------------------- |
+| `url`     | `string`                                      |
+| `data?`   | `any`                                         |
 | `config?` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -437,13 +437,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[put](AxiosInstance.md#put)
+[AxiosInstance](AxiosInstance.md).[put](AxiosInstance.md#put-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:152
 
-___
+---
 
 ### request
 
@@ -451,15 +451,15 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `any` |
-| `R` | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
+| Name | Type                                      |
+| :--- | :---------------------------------------- |
+| `T`  | `any`                                     |
+| `R`  | [`AxiosResponse`](AxiosResponse.md)<`T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                                          |
+| :------- | :-------------------------------------------- |
 | `config` | [`AxiosRequestConfig`](AxiosRequestConfig.md) |
 
 #### Returns
@@ -468,13 +468,13 @@ ___
 
 #### Inherited from
 
-[AxiosInstance](AxiosInstance.md).[request](AxiosInstance.md#request)
+[AxiosInstance](AxiosInstance.md).[request](AxiosInstance.md#request-4)
 
 #### Defined in
 
 node_modules/axios/index.d.ts:146
 
-___
+---
 
 ### spread
 
@@ -483,14 +483,14 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
-| `R` |
+| :--- |
+| `T`  |
+| `R`  |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type                      |
+| :--------- | :------------------------ |
 | `callback` | (...`args`: `T`[]) => `R` |
 
 #### Returns
@@ -501,8 +501,8 @@ ___
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type  |
+| :------ | :---- |
 | `array` | `T`[] |
 
 ##### Returns

--- a/documentation/docs/api/modules.md
+++ b/documentation/docs/api/modules.md
@@ -1,7 +1,7 @@
 ---
-id: "modules"
-title: "@orfium/toolbox"
-sidebar_label: "Exports"
+id: 'modules'
+title: '@orfium/toolbox'
+sidebar_label: 'Exports'
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -39,12 +39,12 @@ custom_edit_url: null
 
 ## Other Functions
 
-- [createAPIInstance](modules.md#createapiinstance)
-- [useAuthentication](modules.md#useauthentication)
+- [createAPIInstance](modules.md#createapiinstance-4)
+- [useAuthentication](modules.md#useauthentication-4)
 
 ## component Functions
 
-- [generateRoutes](modules.md#generateroutes)
+- [generateRoutes](modules.md#generateroutes-4)
 
 ## Type aliases
 
@@ -54,20 +54,20 @@ custom_edit_url: null
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `isAuthenticated` | `boolean` |
-| `isLoading` | `boolean` |
-| `user` | `User` \| `undefined` |
-| `getAccessTokenSilently` | (`opts?`: `GetTokenSilentlyOptions`) => `Promise`<{ `decodedToken`: `Record`<`string`, `unknown`\> ; `token`: `string`  }\> |
-| `loginWithRedirect` | (`o?`: `RedirectLoginOptions`<`any`\>) => `Promise`<`void`\> |
-| `logout` | () => `void` |
+| Name                     | Type                                                                                                                       |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| `isAuthenticated`        | `boolean`                                                                                                                  |
+| `isLoading`              | `boolean`                                                                                                                  |
+| `user`                   | `User` \| `undefined`                                                                                                      |
+| `getAccessTokenSilently` | (`opts?`: `GetTokenSilentlyOptions`) => `Promise`<{ `decodedToken`: `Record`<`string`, `unknown`\> ; `token`: `string` }\> |
+| `loginWithRedirect`      | (`o?`: `RedirectLoginOptions`<`any`\>) => `Promise`<`void`\>                                                               |
+| `logout`                 | () => `void`                                                                                                               |
 
 #### Defined in
 
-[src/authentication/types.ts:8](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/types.ts#L8)
+[src/authentication/types.ts:8](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/types.ts#L8)
 
-___
+---
 
 ### AuthenticationProviderProps
 
@@ -75,19 +75,19 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
+| Name         | Type                 |
+| :----------- | :------------------- |
 | `overrides?` | `Auth0ClientOptions` |
 
 #### Defined in
 
-[src/authentication/types.ts:19](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/types.ts#L19)
+[src/authentication/types.ts:19](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/types.ts#L19)
 
-___
+---
 
 ### Authorization
 
-Ƭ **Authorization**: ``"anonymous"`` \| ``"authorized"`` \| ``"unauthorized"``
+Ƭ **Authorization**: `"anonymous"` \| `"authorized"` \| `"unauthorized"`
 
 **`anonymous:`** general users that can view only public pages - default for all routes without authorization
 
@@ -97,9 +97,9 @@ ___
 
 #### Defined in
 
-[src/routing/Routing.tsx:14](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L14)
+[src/routing/Routing.tsx:14](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L14)
 
-___
+---
 
 ### CreateAPIInstanceProps
 
@@ -107,16 +107,17 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `baseHeaders?` | `Record`<`string`, `string` \| `undefined`\> |
-| `baseUrl` | `string` |
+| Name                 | Type                                         |
+| :------------------- | :------------------------------------------- |
+| `baseHeaders?`       | `Record`<`string`, `string` \| `undefined`\> |
+| `baseUrl`            | `string`                                     |
+| `hasAutomaticToken?` | `boolean`                                    |
 
 #### Defined in
 
-[src/request/createAPIInstance.ts:8](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/createAPIInstance.ts#L8)
+[src/request/createAPIInstance.ts:8](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/createAPIInstance.ts#L8)
 
-___
+---
 
 ### CreateAPIInstanceType
 
@@ -124,22 +125,22 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `instance` | [`AxiosInstance`](interfaces/AxiosInstance.md) |
-| `createRequest` | <T\>(`props`: [`RequestProps`](modules.md#requestprops)) => { `cancelTokenSource`: [`CancelTokenSource`](interfaces/CancelTokenSource.md) ; `request`: () => `Promise`<`T`\>  } |
-| `deleteToken` | () => `void` |
-| `setToken` | (`token`: `string`) => `void` |
+| Name            | Type                                                                                                                                                                             |
+| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instance`      | [`AxiosInstance`](interfaces/AxiosInstance.md)                                                                                                                                   |
+| `createRequest` | <T\>(`props`: [`RequestProps`](modules.md#requestprops-4)) => { `cancelTokenSource`: [`CancelTokenSource`](interfaces/CancelTokenSource.md) ; `request`: () => `Promise`<`T`\> } |
+| `deleteToken`   | () => `void`                                                                                                                                                                     |
+| `setToken`      | (`token`: `string`) => `void`                                                                                                                                                    |
 
 #### Defined in
 
-[src/request/createAPIInstance.ts:13](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/createAPIInstance.ts#L13)
+[src/request/createAPIInstance.ts:14](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/createAPIInstance.ts#L14)
 
-___
+---
 
 ### FallbackPath
 
-Ƭ **FallbackPath**: ``"unauthenticated"`` \| ``"unauthorized"`` \| ``"authenticatedButAnonymous"``
+Ƭ **FallbackPath**: `"unauthenticated"` \| `"unauthorized"` \| `"authenticatedButAnonymous"`
 
 **`unauthenticated:`** in case a user visits a path and has no authentication
 
@@ -149,19 +150,19 @@ ___
 
 #### Defined in
 
-[src/routing/Routing.tsx:22](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L22)
+[src/routing/Routing.tsx:22](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L22)
 
-___
+---
 
 ### Method
 
-Ƭ **Method**: ``"get"`` \| ``"GET"`` \| ``"delete"`` \| ``"DELETE"`` \| ``"head"`` \| ``"HEAD"`` \| ``"options"`` \| ``"OPTIONS"`` \| ``"post"`` \| ``"POST"`` \| ``"put"`` \| ``"PUT"`` \| ``"patch"`` \| ``"PATCH"`` \| ``"purge"`` \| ``"PURGE"`` \| ``"link"`` \| ``"LINK"`` \| ``"unlink"`` \| ``"UNLINK"``
+Ƭ **Method**: `"get"` \| `"GET"` \| `"delete"` \| `"DELETE"` \| `"head"` \| `"HEAD"` \| `"options"` \| `"OPTIONS"` \| `"post"` \| `"POST"` \| `"put"` \| `"PUT"` \| `"patch"` \| `"PATCH"` \| `"purge"` \| `"PURGE"` \| `"link"` \| `"LINK"` \| `"unlink"` \| `"UNLINK"`
 
 #### Defined in
 
 node_modules/axios/index.d.ts:24
 
-___
+---
 
 ### MockRequest
 
@@ -169,33 +170,57 @@ ___
 
 #### Defined in
 
-[src/request/mock.ts:3](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/mock.ts#L3)
+[src/request/mock.ts:3](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/mock.ts#L3)
 
-___
+---
 
-### RequestProps
+### Organization
 
-Ƭ **RequestProps**: { `headers?`: `Record`<`string`, `unknown`\> ; `method`: `Methods` ; `params?`: `Record`<`string`, `unknown`\> ; `url`: `string`  } & `Pick`<[`AxiosRequestConfig`](interfaces/AxiosRequestConfig.md), ``"onUploadProgress"`` \| ``"onDownloadProgress"`` \| ``"responseType"``\>
+Ƭ **Organization**: `Object`
+
+#### Type declaration
+
+| Name                     | Type                                             |
+| :----------------------- | :----------------------------------------------- |
+| `branding`               | { `logo_url`: `string` }                         |
+| `branding.logo_url`      | `string`                                         |
+| `can_administrate`       | `boolean`                                        |
+| `display_name`           | `string`                                         |
+| `metadata`               | { `product_codes`: `string` ; `type`: `string` } |
+| `metadata.product_codes` | `string`                                         |
+| `metadata.type`          | `string`                                         |
+| `name`                   | `string`                                         |
+| `org_id`                 | `string`                                         |
 
 #### Defined in
 
-[src/request/request.ts:16](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/request.ts#L16)
+[src/store/useOrganization.ts:4](https://github.com/Orfium/toolbox/blob/4bb3226/src/store/useOrganization.ts#L4)
 
-___
+---
+
+### RequestProps
+
+Ƭ **RequestProps**: { `headers?`: `Record`<`string`, `unknown`\> ; `method`: `Methods` ; `params?`: `Record`<`string`, `unknown`\> ; `url`: `string` } & `Pick`<[`AxiosRequestConfig`](interfaces/AxiosRequestConfig.md), `"onUploadProgress"` \| `"onDownloadProgress"` \| `"responseType"`\>
+
+#### Defined in
+
+[src/request/request.ts:16](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/request.ts#L16)
+
+---
 
 ### ResponseType
 
-Ƭ **ResponseType**: ``"arraybuffer"`` \| ``"blob"`` \| ``"document"`` \| ``"json"`` \| ``"text"`` \| ``"stream"``
+Ƭ **ResponseType**: `"arraybuffer"` \| `"blob"` \| `"document"` \| `"json"` \| `"text"` \| `"stream"`
 
 #### Defined in
 
 node_modules/axios/index.d.ts:36
 
-___
+---
 
 ### RouteComponentProps
 
-Ƭ **RouteComponentProps**<`T`\>: `ReactRouterRouteComponentProps`<`any`\> & { `extraProps`: `T`  }
+Ƭ **RouteComponentProps**<`T`\>: `ReactRouterRouteComponentProps`<`any`\> & { `extraProps`: `T` }
 
 This is actual part of the library so you can skip it.
 An extension of the React Router Component props to be used with the extra props.
@@ -203,15 +228,15 @@ Is being used to the route component to extend its functionality on types
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `unknown` |
+| Name | Type      |
+| :--- | :-------- |
+| `T`  | `unknown` |
 
 #### Defined in
 
-[src/routing/Routing.tsx:35](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L35)
+[src/routing/Routing.tsx:35](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L35)
 
-___
+---
 
 ### RouteItem
 
@@ -219,18 +244,18 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `authorization?` | [`Authorization`](modules.md#authorization) | The authorization level of the route, there are 3: 'anonymous' \| 'authorized' \| 'unauthorized' -  **`defaultvalue:`** 'anonymous' |
-| `component?` | `React.FunctionComponent`<[`RouteComponentProps`](modules.md#routecomponentprops)\> | A component that the route renders as page. This has all the props and extraProps that have been passed to that route |
-| `extraProps?` | `unknown` | Any custom/extra props that are going to be available on the component |
-| `path` | `string` \| `string`[] | The url path or paths of the route that will listen to in order to render |
+| Name             | Type                                                                                  | Description                                                                                                                        |
+| :--------------- | :------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------- |
+| `authorization?` | [`Authorization`](modules.md#authorization-4)                                         | The authorization level of the route, there are 3: 'anonymous' \| 'authorized' \| 'unauthorized' - **`defaultvalue:`** 'anonymous' |
+| `component?`     | `React.FunctionComponent`<[`RouteComponentProps`](modules.md#routecomponentprops-4)\> | A component that the route renders as page. This has all the props and extraProps that have been passed to that route              |
+| `extraProps?`    | `unknown`                                                                             | Any custom/extra props that are going to be available on the component                                                             |
+| `path`           | `string` \| `string`[]                                                                | The url path or paths of the route that will listen to in order to render                                                          |
 
 #### Defined in
 
-[src/routing/Routing.tsx:41](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L41)
+[src/routing/Routing.tsx:41](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L41)
 
-___
+---
 
 ### RoutingStructure
 
@@ -238,24 +263,24 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `fallbackPaths?` | `Partial`<`Record`<[`FallbackPath`](modules.md#fallbackpath), `string`\>\> | Holder of paths relative to the types of authorization. For every type there is a fallback path that a user will be redirected if they don't have access to it based on the authorization |
-| `routes` | [`RouteItem`](modules.md#routeitem)[] | - |
+| Name             | Type                                                                         | Description                                                                                                                                                                               |
+| :--------------- | :--------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fallbackPaths?` | `Partial`<`Record`<[`FallbackPath`](modules.md#fallbackpath-4), `string`\>\> | Holder of paths relative to the types of authorization. For every type there is a fallback path that a user will be redirected if they don't have access to it based on the authorization |
+| `routes`         | [`RouteItem`](modules.md#routeitem-4)[]                                      | -                                                                                                                                                                                         |
 
 #### Defined in
 
-[src/routing/Routing.tsx:24](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L24)
+[src/routing/Routing.tsx:24](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L24)
 
-___
+---
 
 ### TopBarProps
 
-Ƭ **TopBarProps**: { `logoIcon`: `JSX.Element` ; `userMenu?`: `UserMenuProps`  } & `Omit`<`TopAppBarProps`, ``"logoIcon"`` \| ``"userMenu"``\>
+Ƭ **TopBarProps**: { `logoIcon`: `JSX.Element` ; `userMenu?`: `never` } & `Omit`<`TopAppBarProps`, `"logoIcon"` \| `"userMenu"`\>
 
 #### Defined in
 
-[src/authentication/TopBar.tsx:9](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/TopBar.tsx#L9)
+[src/authentication/TopBar.tsx:9](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/TopBar.tsx#L9)
 
 ## Variables
 
@@ -265,9 +290,9 @@ ___
 
 #### Defined in
 
-[src/authentication/Authentication.tsx:18](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/Authentication.tsx#L18)
+[src/authentication/Authentication.tsx:18](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/Authentication.tsx#L18)
 
-___
+---
 
 ### AuthenticationProvider
 
@@ -275,9 +300,9 @@ ___
 
 #### Defined in
 
-[src/authentication/context.tsx:111](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/context.tsx#L111)
+[src/authentication/context.tsx:115](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/context.tsx#L115)
 
-___
+---
 
 ### METHODS
 
@@ -285,9 +310,9 @@ ___
 
 #### Defined in
 
-[src/request/request.ts:14](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/request.ts#L14)
+[src/request/request.ts:14](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/request.ts#L14)
 
-___
+---
 
 ### MockRequest
 
@@ -295,53 +320,71 @@ ___
 
 #### Defined in
 
-[src/request/mock.ts:4](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/mock.ts#L4)
+[src/request/mock.ts:4](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/mock.ts#L4)
 
-___
+---
 
-### orfiumIdBaseInstance
+### default
 
-• `Const` **orfiumIdBaseInstance**: [`CreateAPIInstanceType`](modules.md#createapiinstancetype)
+• **default**: `Object`
+
+#### Type declaration
+
+| Name                                   | Type                                                                                                                                                    |
+| :------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useOrganization`                      | { `organizations`: [`Organization`](modules.md#organization-2)[] ; `selectedOrganization`: `undefined` \| [`Organization`](modules.md#organization-2) } |
+| `useOrganization.organizations`        | [`Organization`](modules.md#organization-2)[]                                                                                                           |
+| `useOrganization.selectedOrganization` | `undefined` \| [`Organization`](modules.md#organization-2)                                                                                              |
 
 #### Defined in
 
-[src/request/index.ts:6](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/index.ts#L6)
+[src/index.ts:9](https://github.com/Orfium/toolbox/blob/4bb3226/src/index.ts#L9)
+
+---
+
+### orfiumIdBaseInstance
+
+• `Const` **orfiumIdBaseInstance**: [`CreateAPIInstanceType`](modules.md#createapiinstancetype-4)
+
+#### Defined in
+
+[src/request/index.ts:6](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/index.ts#L6)
 
 ## Other Functions
 
 ### createAPIInstance
 
-▸ **createAPIInstance**(`__namedParameters`): [`CreateAPIInstanceType`](modules.md#createapiinstancetype)
+▸ **createAPIInstance**(`__namedParameters`): [`CreateAPIInstanceType`](modules.md#createapiinstancetype-4)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | [`CreateAPIInstanceProps`](modules.md#createapiinstanceprops) |
+| Name                | Type                                                            |
+| :------------------ | :-------------------------------------------------------------- |
+| `__namedParameters` | [`CreateAPIInstanceProps`](modules.md#createapiinstanceprops-4) |
 
 #### Returns
 
-[`CreateAPIInstanceType`](modules.md#createapiinstancetype)
+[`CreateAPIInstanceType`](modules.md#createapiinstancetype-4)
 
 #### Defined in
 
-[src/request/createAPIInstance.ts:30](https://github.com/Orfium/toolbox/blob/a0882ae/src/request/createAPIInstance.ts#L30)
+[src/request/createAPIInstance.ts:31](https://github.com/Orfium/toolbox/blob/4bb3226/src/request/createAPIInstance.ts#L31)
 
-___
+---
 
 ### useAuthentication
 
-▸ **useAuthentication**(): [`AuthenticationContextProps`](modules.md#authenticationcontextprops)
+▸ **useAuthentication**(): [`AuthenticationContextProps`](modules.md#authenticationcontextprops-4)
 
 #### Returns
 
-[`AuthenticationContextProps`](modules.md#authenticationcontextprops)
+[`AuthenticationContextProps`](modules.md#authenticationcontextprops-4)
 
 #### Defined in
 
-[src/authentication/context.tsx:188](https://github.com/Orfium/toolbox/blob/a0882ae/src/authentication/context.tsx#L188)
+[src/authentication/context.tsx:192](https://github.com/Orfium/toolbox/blob/4bb3226/src/authentication/context.tsx#L192)
 
-___
+---
 
 ## component Functions
 
@@ -355,12 +398,12 @@ If the fallbacks are defined then those will be used instead.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | Component properties |
-| `props.fallbackComponent?` | `ComponentType`<{}\> | The component that will render if none of the routes match the url location - @default Page not found |
-| `props.isAuthenticated` | `boolean` | A boolean that are passed from the parent Application to let the generation of routes know the state of the user |
-| `props.structure` | [`RoutingStructure`](modules.md#routingstructure) | A list of Routes that needs to render with authorization level and extra props. |
+| Name                       | Type                                                | Description                                                                                                      |
+| :------------------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| `props`                    | `Object`                                            | Component properties                                                                                             |
+| `props.fallbackComponent?` | `ComponentType`<{}\>                                | The component that will render if none of the routes match the url location - @default Page not found            |
+| `props.isAuthenticated`    | `boolean`                                           | A boolean that are passed from the parent Application to let the generation of routes know the state of the user |
+| `props.structure`          | [`RoutingStructure`](modules.md#routingstructure-4) | A list of Routes that needs to render with authorization level and extra props.                                  |
 
 #### Returns
 
@@ -368,4 +411,4 @@ If the fallbacks are defined then those will be used instead.
 
 #### Defined in
 
-[src/routing/Routing.tsx:62](https://github.com/Orfium/toolbox/blob/a0882ae/src/routing/Routing.tsx#L62)
+[src/routing/Routing.tsx:62](https://github.com/Orfium/toolbox/blob/4bb3226/src/routing/Routing.tsx#L62)

--- a/documentation/docs/api/namespaces/Authentication.md
+++ b/documentation/docs/api/namespaces/Authentication.md
@@ -1,7 +1,7 @@
 ---
-id: "Authentication"
-title: "Namespace: Authentication"
-sidebar_label: "Authentication"
+id: 'Authentication'
+title: 'Namespace: Authentication'
+sidebar_label: 'Authentication'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -10,4 +10,4 @@ custom_edit_url: null
 
 ### TopBar
 
-• **TopBar**: `FC`<[`TopBarProps`](../modules.md#topbarprops)\>
+• **TopBar**: `FC`<[`TopBarProps`](../modules.md#topbarprops-4)\>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
+import useOrganization from './store/useOrganization';
+
 export * from './request';
 export * from './routing';
 export * from './authentication';
+
+export default {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useOrganization: useOrganization(({ organizations, selectedOrganization }) => ({
+    organizations,
+    selectedOrganization,
+  })),
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
-import useOrganization from './store/useOrganization';
+import useOrganization, { Organization } from './store/useOrganization';
 
 export * from './request';
 export * from './routing';
 export * from './authentication';
+
+export type { Organization };
 
 export default {
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/store/useOrganization.ts
+++ b/src/store/useOrganization.ts
@@ -16,7 +16,9 @@ export type Organization = {
 };
 
 type Store = {
+  // list of organizations that fetched and stored
   organizations: Organization[];
+  // the selected organization for the current session
   selectedOrganization: Organization | undefined;
   setOrganizations: (organizations: Organization[]) => void;
   setSelectedOrganization: (organizations: Organization) => void;


### PR DESCRIPTION

## Description

This PR exposes partially the organization store information. The information for now only consists of the `organizations` and the `selectedOrganization`.

This will serve as stand-alone module and if in the future we will have many like this we can create one `useSSO` that will export many modules as one.


<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
