### PR TITLE
fix: remove unwanted localstorage to fix error on login

### DIFF
--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -27,8 +27,6 @@ const providerConfig: Auth0ClientOptions = {
   redirect_uri: window.location.origin,
   onRedirectCallback,
   useRefreshTokens: true,
-  // this way we persist the token to not refetch on reload - https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options
-  cacheLocation: 'localstorage',
 };
 
 export const AuthenticationContext = createContext<AuthenticationContextProps>({


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

This is the part the removed the localstorage from toolbox in order to prevent the error going on. The error was misleading and after consideration we removed this kind of storage.

more info on why [here](https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options)

related PR [here](https://github.com/Orfium/orfium-one/pull/90#issuecomment-1239277890)
