### PR TITLE
fix: always throw error when Promise returns an AxiosError

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 yarn lint-staged
-yarn test && lint-staged && yarn run tsc -p .
+yarn test && yarn lint-staged && yarn run tsc -p .

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-    "pre-commit": "yarn test && lint-staged && tsc -p ."
+    "pre-commit": "yarn test && yarn lint-staged && tsc -p ."
   }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,5 @@
 {
   "trailingComma": "es5",
   "printWidth": 100,
-  "singleQuote": true,
-  "endOfLine": "auto"
+  "singleQuote": true
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
   "printWidth": 100,
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-query": "^3.22.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.72.0",
     "rollup-plugin-dts": "^4.2.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/src/authentication/authentication.test.tsx
+++ b/src/authentication/authentication.test.tsx
@@ -56,6 +56,8 @@ describe('Authorization: ', () => {
 
   it('redirects to login if not authenticated', async () => {
     isAuthenticated.mockResolvedValue(false);
+    getTokenSilently.mockResolvedValue(getNewFakeToken());
+    mock.onGet('/memberships/').replyOnce(200, []);
 
     render(
       <AuthenticationProvider>

--- a/src/request/utils.ts
+++ b/src/request/utils.ts
@@ -8,9 +8,9 @@ import { AxiosPromise, AxiosError } from 'axios';
  * @returns {AxiosResponse | AxiosError} The API response
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const axiosPromiseResult = <T = any>(axiosPromise: AxiosPromise<T>): Promise<T> =>
+export const axiosPromiseResult = async <T = any>(axiosPromise: AxiosPromise<T>): Promise<T> =>
   axiosPromise
-    .then(({ data }) => data)
+    .then((props) => (typeof props.data !== 'undefined' ? props.data : Promise.reject(props)))
     .catch((error: AxiosError<T>) => {
       throw error;
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,9 +3791,9 @@ flatted@^3.1.0:
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 follow-redirects@^1.14.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
-  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

#### Issue: 
When HTTP response status codes 4XX occur, axiosPromiseResult function doesn't handle them properly by throwing an error


<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
