### PR TITLE
[DEV-112] feat: add invitation flow logic for new users

### DIFF
--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -59,17 +59,15 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
         if (!selectedOrganization?.org_id && data?.length > 0) {
           setSelectedOrganization(data[0]);
         }
-
-        // if token doesn't have an organization set continue and set one
-        if (!decodedToken?.org_id) {
-          if (data?.length) {
-            // IMPORTANT - when we are using `useRefreshTokens` and `cacheLocation` on Auth0 we can fetch just a token with organization through `getTokenSilently`
-            // we must use loginWithRedirect in that case thus this is happening here
-            // https://auth0.com/docs/secure/tokens/refresh-tokens/use-refresh-token-rotation
-            await loginWithRedirect({
-              organization: selectedOrganization?.org_id || data[0].org_id,
-            });
-          }
+        // if token doesn't have an organization and the user has available organizations
+        // set continue and set one
+        if (!decodedToken?.org_id && data?.length) {
+          // IMPORTANT - when we are using `useRefreshTokens` and `cacheLocation` on Auth0 we can fetch just a token with organization through `getTokenSilently`
+          // we must use loginWithRedirect in that case thus this is happening here
+          // https://auth0.com/docs/secure/tokens/refresh-tokens/use-refresh-token-rotation
+          await loginWithRedirect({
+            organization: selectedOrganization?.org_id || data[0].org_id,
+          });
         } else {
           // set false at all times
           setSystemLoading(false);

--- a/src/authentication/context.test.tsx
+++ b/src/authentication/context.test.tsx
@@ -2,6 +2,7 @@ import { act, findByText, getByTestId, render, waitFor, screen } from '@testing-
 import jwtDecode from 'jwt-decode';
 import React, { useEffect, useState } from 'react';
 
+// Auth0 custom error simulator. This extends a regular Error to match Auth0 Error.
 class CustomError extends Error {
   constructor(public error: string, public error_description: string) {
     super(error_description);
@@ -34,6 +35,7 @@ import {
 
 describe('Context', () => {
   beforeEach(() => {
+    // clear all mocks and mocked values
     jest.clearAllMocks();
     mockedGetTokenSilently.mockReset();
     getUser.mockReset();

--- a/src/authentication/context.test.tsx
+++ b/src/authentication/context.test.tsx
@@ -1,6 +1,14 @@
-import { cleanup, findByText, getByTestId, render, waitFor } from '@testing-library/react';
+import { act, findByText, getByTestId, render, waitFor, screen } from '@testing-library/react';
 import jwtDecode from 'jwt-decode';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+
+class CustomError extends Error {
+  constructor(public error: string, public error_description: string) {
+    super(error_description);
+    this.error = error;
+    this.error_description = error_description;
+  }
+}
 
 import {
   FAKE_TOKEN,
@@ -10,6 +18,7 @@ import {
   loginWithPopup as mockedLoginWithPopup,
   getNewFakeToken,
   fakeTokenData,
+  loginWithRedirect,
   // @ts-ignore
 } from '../../__mocks__/@auth0/auth0-spa-js';
 import useOrganization from '../store/useOrganization';
@@ -24,6 +33,13 @@ import {
 } from './context';
 
 describe('Context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetTokenSilently.mockReset();
+    getUser.mockReset();
+    loginWithRedirect.mockReset();
+  });
+
   describe('global methods that used on both context and outside', () => {
     const oldWindowLocation = { ...window.location };
 
@@ -128,24 +144,37 @@ describe('Context', () => {
   });
 
   test('AuthenticationProvider calls loginWithPopup when access token fails', async () => {
+    const errorMsg = 'login_required';
     const TestingComponent = () => {
       const { user, isAuthenticated, getAccessTokenSilently, isLoading } = useAuthentication();
+      const [result, setResult] = useState('');
 
       useEffect(() => {
-        if (!isLoading) {
-          getAccessTokenSilently();
-        }
+        (async () => {
+          if (!isLoading) {
+            try {
+              const res = await getAccessTokenSilently();
+
+              setResult(res.token);
+            } catch (err: any) {
+              console.log(err);
+              console.log(err.error);
+              setResult(err.error);
+            }
+          }
+        })();
       }, [isLoading]);
 
       return (
         <>
           <p>{user?.name}</p>
           <p data-testid="isAuthenticated">{isAuthenticated?.toString()}</p>
+          <p data-testid="result">{result}</p>
         </>
       );
     };
 
-    mockedGetTokenSilently.mockRejectedValue({ error: 'login_required' });
+    mockedGetTokenSilently.mockRejectedValue(new CustomError(errorMsg, 'login_require'));
     getUser.mockResolvedValue({
       name: 'John Doe',
     });
@@ -159,5 +188,43 @@ describe('Context', () => {
     await waitFor(() => expect(findByText('John Doe')).toBeTruthy());
     await waitFor(() => expect(getByTestId('isAuthenticated').innerHTML).toBe('true'));
     await waitFor(() => expect(mockedLoginWithPopup).toBeCalledTimes(1));
+    await waitFor(() => expect(getByTestId('result').innerHTML).toBe(errorMsg));
   }, 10000);
+
+  test('invitation redirect', async () => {
+    const invitation = 'wkhLzqInxdaXipRfBPyBtzcxs3wmoUDg';
+    const organization = 'org_lWF9avilXAry9Aid';
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        search: `?invitation=${invitation}&organization=${organization}`,
+      },
+    });
+
+    isAuthenticated.mockResolvedValue(false);
+
+    await act(async () => {
+      const TestingComponent = () => {
+        const { user, isAuthenticated, isLoading } = useAuthentication();
+
+        return (
+          <>
+            <p>{user?.name}</p>
+            <p data-testid="isAuthenticated">{isAuthenticated?.toString()}</p>
+            <p data-testid="isLoading">{isLoading?.toString()}</p>
+          </>
+        );
+      };
+
+      render(
+        <AuthenticationProvider>
+          <TestingComponent />
+        </AuthenticationProvider>
+      );
+    });
+
+    await waitFor(() => expect(screen.getByTestId('isLoading').innerHTML).toBe('false'));
+    await waitFor(() => expect(loginWithRedirect).toBeCalledTimes(1));
+    expect(loginWithRedirect).toBeCalledWith({ invitation, organization });
+  });
 });

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -164,7 +164,7 @@ const AuthenticationProvider: React.FC = ({ children }) => {
         await loginWithPopup();
       }
 
-      return e;
+      throw e;
     }
   };
 

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -116,6 +116,9 @@ const AuthenticationProvider: React.FC = ({ children }) => {
   const [auth0Client, setAuth0Client] = useState<Auth0Client>();
   const [isLoading, setIsLoading] = useState(true);
   const [__popupOpen, setPopupOpen] = useState(false);
+  const params = new URLSearchParams(window.location.search);
+  const organization = params.get('organization');
+  const invitation = params.get('invitation');
 
   useEffect(() => {
     (async () => {
@@ -167,7 +170,10 @@ const AuthenticationProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      auth0Client!.loginWithRedirect();
+      auth0Client!.loginWithRedirect({
+        organization: organization || undefined,
+        invitation: invitation || undefined,
+      });
     }
   }, [auth0Client, isLoading, isAuthenticated]);
 


### PR DESCRIPTION
## Description

This PR introduce the invitation flow for our integrated SPAs. The flow is as follows, the email pass `invitation` and `organization` that the user is invited from and it opens on URL with those attached. Our library reads this and redirect the user to the consent section.

PR to test it out -> https://github.com/Orfium/orfium-one/pull/98

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot
![Screen Recording 2022-09-15 at 5 12 37 PM](https://user-images.githubusercontent.com/6433679/190427047-0193aaa6-3ad7-45d4-add5-9a6280201566.gif)

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan
* Testing the invitation flow that gets the correct params
* Fix testing with failed error
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
