### PR TITLE
[DEV-110] fix: reclaim token on organization switching

### DIFF
--- a/src/authentication/context.test.tsx
+++ b/src/authentication/context.test.tsx
@@ -108,7 +108,21 @@ describe('Context', () => {
     test('with cached results', async () => {
       const NEW_FAKE_EXPIRED_TOKEN = getNewFakeToken();
       const setToken = useRequestToken.getState().setToken;
+      const setSelectedOrganization = useOrganization.getState().setSelectedOrganization;
       setToken(NEW_FAKE_EXPIRED_TOKEN);
+      setSelectedOrganization({
+        org_id: 'org_WYZLEMyTm2xEbnbn',
+        display_name: 'test',
+        name: 'test',
+        can_administrate: true,
+        metadata: {
+          type: 'test',
+          product_codes: 'test',
+        },
+        branding: {
+          logo_url: 'test',
+        },
+      });
 
       const { token, decodedToken } = await getTokenSilently();
 

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -95,7 +95,7 @@ export const getTokenSilently = async (
       ? new Date(decodedToken?.exp * 1000).getTime() < new Date().getTime()
       : true; // has expired
 
-  if (!isExpired && decodedToken.org_id) {
+  if (!isExpired && decodedToken.org_id && decodedToken.org_id === selectedOrganization?.org_id) {
     return { token: stateToken, decodedToken };
   }
 


### PR DESCRIPTION
## Description

This PR focus to fix the re-claim of a new token when an organization changes from the switcher. Currently there was a bug that was returning the cached token till it was invalid (based on time). 

We added a new rule to check if the decoded organization is the same as the organization selected in order to fetch something new.

resolves #25
<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot
Demonstration on orfium one that fetch different products based on different organization
![Screen Recording 2022-10-05 at 11 41 05 AM](https://user-images.githubusercontent.com/6433679/194019182-c33ae70b-832d-4e13-9391-35713eec23a8.gif)

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan
Updated test based on cached results for the token

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
