### PR TITLE
[DVP-89][DVP-115] fix: reloads on organization switch

### DIFF
--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -61,7 +61,7 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
       setSystemLoading(true);
       (async () => {
         // moving this will affect the app. If this is moved below when clearing the storage the app constantly refresh
-        const { decodedToken } = await getAccessTokenSilently();
+        const response = await getAccessTokenSilently();
         // @TODO in the future we must define the org_id
         const requestInstance = orfiumIdBaseInstance.createRequest<Organization[]>({
           method: 'get',
@@ -76,7 +76,7 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
         }
         // if token doesn't have an organization and the user has available organizations
         // set continue and set one
-        if (!decodedToken?.org_id && data?.length) {
+        if (!response?.decodedToken?.org_id && data?.length) {
           // IMPORTANT - when we are using `useRefreshTokens` and `cacheLocation` on Auth0 we can fetch just a token with organization through `getTokenSilently`
           // we must use loginWithRedirect in that case thus this is happening here
           // https://auth0.com/docs/secure/tokens/refresh-tokens/use-refresh-token-rotation

--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -91,7 +91,9 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
         }
       })();
     }
-  }, [getAccessTokenSilently, selectedOrganization?.org_id]);
+    // @NOTE selectedOrganization?.org_id, isLoading, systemLoading
+    // are missing on purpose from the deps as these are being updated from places where the organization id is being handled with refresh from auth0
+  }, [getAccessTokenSilently, loginWithRedirect, setOrganizations, setSelectedOrganization]);
 
   // when loading is true before navigation this is not showing anymore
   if (systemLoading === undefined || systemLoading || isLoading || !isAuthenticated) {

--- a/src/authentication/components/TopBar/TopBar.tsx
+++ b/src/authentication/components/TopBar/TopBar.tsx
@@ -53,6 +53,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
                 const foundOrg = organizations.find((org) => org.display_name === option);
                 if (foundOrg) {
                   const client = await getAuth0Client();
+                  await client.logout({ openUrl: false });
                   await client.loginWithRedirect({
                     authorizationParams: {
                       organization: foundOrg.org_id,

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -32,6 +32,7 @@ export const providerConfig: Auth0ClientOptions = {
   },
   useRefreshTokens: true,
   cacheLocation: 'localstorage',
+  useRefreshTokensFallback: true, // fix issue with logout https://community.auth0.com/t/auth0-spa-2-x-returning-missing-refresh-token/98999/18
 };
 
 export const defaultContextValues: AuthenticationContextProps = {

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -220,8 +220,6 @@ const AuthenticationProvider: React.FC = ({ children }) => {
       }
 
       handleError(error);
-
-      return error;
     }
   };
 

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -47,9 +47,10 @@ export type AuthenticationContextProps = {
   isLoading: boolean;
   loginWithRedirect(o?: RedirectLoginOptions): Promise<void>;
   logout: () => void;
-  getAccessTokenSilently: (
-    opts?: GetTokenSilentlyOptions
-  ) => Promise<{ token: string; decodedToken: DecodedTokenResponse | Record<string, never> }>;
+  getAccessTokenSilently: (opts?: GetTokenSilentlyOptions) => Promise<{
+    token: string;
+    decodedToken: DecodedTokenResponse | Record<string, never>;
+  } | void>;
   user: User | undefined;
 };
 


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

this is a quick patch on the switch-organization fix that we introduced https://github.com/Orfium/toolbox/pull/66

It eliminates refreshes by removing the dependency from `useEffect` because any change on the organization selected is being handled by the auth0 with redirects.

Also, it addresses the issue with the logout. this is a known issue and I also left a comment which also resolves this https://orfium.atlassian.net/jira/software/c/projects/DVP/boards/298?modal=detail&selectedIssue=DVP-115


## Test Plan

No need to update something
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
