### PR TITLE
fix: moving react-router-dom 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orfium/toolbox",
-  "version": "1.13.0-rc.3",
+  "version": "0.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orfium/toolbox",
-  "version": "0.0.0",
+  "version": "1.13.0-rc.3",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
@@ -14,7 +14,8 @@
     "axios-mock-adapter": "^1.19.0",
     "jwt-decode": "^3.1.2",
     "react-error-boundary": "^3.1.4",
-    "zustand": "^4.0.0-rc.1"
+    "zustand": "^4.0.0-rc.1",
+    "react-router-dom": "^5.3.1"
   },
   "devDependencies": {
     "@amanda-mitchell/semantic-release-npm-multiple": "^3.5.0",
@@ -73,8 +74,7 @@
     "@sentry/browser": "^7.0.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "react-query": "^3.10.0",
-    "react-router-dom": "^5.3.1"
+    "react-query": "^3.10.0"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/src/routing/index.tsx
+++ b/src/routing/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+// @deprecated This module is about to be deprecated in the next version as it will be handled by monorepo utils
+// That is why we keep react-router-dom as dependency in package.json
 
-export { BrowserRouter, Route, Redirect } from 'react-router-dom';
+export { BrowserRouter, Redirect, Route } from 'react-router-dom';
 export * from './Routing';


### PR DESCRIPTION
This PR is moving react-router-dom to dependencies for handling different versions on projects with v6. Having router inside this project will be deprecated in the future