### PR TITLE
feat: add custom Menu component

### DIFF
--- a/src/authentication/components/Menu/Menu.style.ts
+++ b/src/authentication/components/Menu/Menu.style.ts
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import {
+  MenuPositionAllowed,
+  optionsStyle,
+} from '@orfium/ictinus/dist/components/utils/DropdownOptions';
+import { rem } from '@orfium/ictinus/dist/theme/utils';
+
+export const Wrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+export const Button = styled.button`
+  position: relative;
+  color: ${({ textColor }: { textColor: string }) => textColor};
+  border: none;
+  display: flex;
+  font-size: ${({ theme }) => theme.typography.fontSizes['14']};
+  align-items: center;
+  padding: 0;
+
+  > span {
+    padding-right: ${({ theme }) => theme.spacing.sm};
+    display: inline-block;
+  }
+`;
+
+export const Tag = styled.span<{ backgroundColor: string; textColor: string }>`
+  font-size: ${({ theme }) => theme.typography.fontSizes[12]};
+  padding: ${({ theme }) => theme.spacing.xsm};
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  color: ${({ textColor }) => textColor};
+  border-radius: ${rem(2)};
+`;
+export const Option = styled.span<{ menuPosition: MenuPositionAllowed }>`
+  ${({ theme, menuPosition }) => optionsStyle({ menuPosition })(theme)}
+`;

--- a/src/authentication/components/Menu/Menu.tsx
+++ b/src/authentication/components/Menu/Menu.tsx
@@ -1,0 +1,73 @@
+import { Icon, List, useTheme } from '@orfium/ictinus';
+import * as React from 'react';
+
+import ClickAwayListener from '@orfium/ictinus/dist/components/utils/ClickAwayListener';
+import { MenuPositionAllowed } from '@orfium/ictinus/dist/components/utils/DropdownOptions';
+import { Button, Option, Tag, Wrapper } from './Menu.style';
+
+export type Props = {
+  /** Items that are being declared as menu options */
+  items?: string[];
+  /** A callback that is being triggered when an items has been clicked */
+  onSelect: (option: string) => void;
+  /** The text of the button to show - defaults to "More" */
+  buttonText: React.ReactNode;
+  /** The text of the tag to show - defaults to undefined */
+  tagText: React.ReactNode;
+  /** Define if the button is in disabled state */
+  disabled?: boolean;
+  /** Menu position when open */
+  menuPosition?: MenuPositionAllowed;
+};
+
+export type TestProps = {
+  dataTestId?: string;
+};
+
+const Menu: React.FC<Props & TestProps> = (props) => {
+  const {
+    items,
+    disabled,
+    onSelect,
+    buttonText = 'More',
+    menuPosition = 'left',
+    dataTestId,
+    tagText,
+  } = props;
+  const [open, setOpen] = React.useState(false);
+  const theme = useTheme();
+  const textColor = theme.utils.getColor('blue', 600);
+  const backgroundColor = theme.utils.getColor('lightGrey', 100);
+
+  return (
+    <ClickAwayListener onClick={() => setOpen(false)}>
+      <Wrapper data-testid={dataTestId}>
+        <Button disabled={disabled} textColor={textColor} onClick={() => setOpen((open) => !open)}>
+          <span>{buttonText}</span>{' '}
+          <Icon name={open ? 'triangleUp' : 'triangleDown'} size={11} color={textColor} />
+        </Button>
+        {tagText && (
+          <Tag backgroundColor={backgroundColor} textColor={textColor}>
+            {tagText}
+          </Tag>
+        )}
+        {open && (
+          <Option menuPosition={menuPosition}>
+            {items && (
+              <List
+                data={items}
+                rowSize={'small'}
+                handleOptionClick={(option: string) => {
+                  setOpen(false);
+                  onSelect(option);
+                }}
+              />
+            )}
+          </Option>
+        )}
+      </Wrapper>
+    </ClickAwayListener>
+  );
+};
+
+export default Menu;

--- a/src/authentication/components/Menu/index.ts
+++ b/src/authentication/components/Menu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Menu';


### PR DESCRIPTION
Resolves [DSTRBTN-540]

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new `Menu` component in the `authentication` module. The `Menu` component is a dropdown menu that can be used to display a list of options to the user. It includes a button that toggles the visibility of the menu and a tag that can be used to display additional information.
> 
> ## What changed
> Three new files were added in the `authentication/components/Menu` directory:
> 
> 1. `Menu.style.ts`: This file contains the styled components used in the `Menu` component. It includes styles for the wrapper, button, tag, and option elements.
> 
> 2. `Menu.tsx`: This is the main file for the `Menu` component. It uses the styled components from `Menu.style.ts` and includes the logic for toggling the visibility of the menu and handling option selection.
> 
> 3. `index.ts`: This file exports the `Menu` component for use in other parts of the application.
> 
> ## How to test
> To test this change, you can import the `Menu` component into any component in the `authentication` module and use it as follows:
> 
> ```jsx
> import Menu from './Menu';
> 
> <Menu
>   items={['Option 1', 'Option 2', 'Option 3']}
>   onSelect={(option) => console.log(option)}
>   buttonText="More"
>   tagText="Tag"
> />
> ```
> 
> This will render a button labeled "More" and a tag labeled "Tag". Clicking on the button will toggle the visibility of a menu with the options "Option 1", "Option 2", and "Option 3". Selecting an option will log the selected option to the console.
> 
> ## Why make this change
> This change was made to provide a reusable `Menu` component that can be used to display a list of options to the user. This can be useful in a variety of scenarios, such as providing a list of actions that the user can perform on a particular item.
</details>

[DSTRBTN-540]: https://orfium.atlassian.net/browse/DSTRBTN-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ