### PR TITLE
feat: Update ocntext and useProducts hook

### DIFF
--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -6,11 +6,11 @@ import {
   RedirectLoginOptions,
 } from '@auth0/auth0-spa-js';
 import jwt_decode from 'jwt-decode';
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import { useErrorHandler } from 'react-error-boundary';
-
-import useOrganization from '../store/useOrganization';
-import useRequestToken from '../store/useRequestToken';
+import { useOrfiumProducts } from '../hooks/useOrfiumProducts';
+import useOrganization from '../store/organizations';
+import useRequestToken from '../store/requestToken';
 import { config } from './config';
 import { AuthenticationContextProps } from './types';
 
@@ -39,6 +39,10 @@ export const defaultContextValues: AuthenticationContextProps = {
   isAuthenticated: false,
   isLoading: false,
   user: undefined,
+  orfiumProducts: null,
+  organizations: [],
+  selectedOrganization: null,
+  switchOrganization: (__x) => {},
   loginWithRedirect: () => Promise.resolve(),
   logout: () => Promise.resolve('logged out'),
   getAccessTokenSilently: () => Promise.resolve({ token: '', decodedToken: {} }),
@@ -143,14 +147,26 @@ const AuthenticationProvider: React.FC = ({ children }) => {
   const [user, setUser] = useState<Record<string, unknown>>();
   const [auth0Client, setAuth0Client] = useState<Auth0Client>();
   const [isLoading, setIsLoading] = useState(true);
+  // const [products, setProducts] = useState<Product[] | null>(null);
+  // handleError is referentially stable, so it's safe to use as a dep in dep array
+  // https://github.com/bvaughn/react-error-boundary/blob/v3.1.4/src/index.tsx#L165C10-L165C18
   const handleError = useErrorHandler();
   const params = new URLSearchParams(window.location.search);
 
   const selectedOrganization = useOrganization((state) => state.selectedOrganization);
   const setSelectedOrganization = useOrganization((state) => state.setSelectedOrganization);
-  const organizations = useOrganization((state) => state.organizations);
+  const organizationsDict = useOrganization((state) => state.organizations);
+  const organizationsList = useOrganization((state) => state.organizationsList);
   const organization = params.get('organization') || selectedOrganization?.org_id;
   const invitation = params.get('invitation');
+
+  const organizations = useMemo(() => {
+    if (organizationsDict && organizationsList) {
+      return organizationsList.map((x) => organizationsDict[x]);
+    }
+
+    return [];
+  }, [organizationsDict, organizationsList]);
 
   useEffect(() => {
     (async () => {
@@ -195,33 +211,39 @@ const AuthenticationProvider: React.FC = ({ children }) => {
     })();
   }, []);
 
-  const loginWithRedirect = async (o: RedirectLoginOptions) => {
-    try {
-      const client = await getAuth0Client();
-      await client.loginWithRedirect(o);
-    } catch (error) {
-      return handleError(error);
-    }
-  };
-
-  const getAccessTokenSilently = async (opts?: GetTokenSilentlyOptions) => {
-    try {
-      const result = await getTokenSilently(opts);
-
-      return result;
-    } catch (error: any) {
-      if (error?.error === 'login_required' || error?.error === 'consent_required') {
-        return loginWithRedirect({
-          authorizationParams: {
-            organization: organization || undefined,
-            invitation: invitation || undefined,
-          },
-        });
+  const loginWithRedirect = useCallback(
+    async (o: RedirectLoginOptions) => {
+      try {
+        const client = await getAuth0Client();
+        await client.loginWithRedirect(o);
+      } catch (error) {
+        return handleError(error);
       }
+    },
+    [handleError]
+  );
 
-      handleError(error);
-    }
-  };
+  const getAccessTokenSilently = useCallback(
+    async (opts?: GetTokenSilentlyOptions) => {
+      try {
+        const result = await getTokenSilently(opts);
+
+        return result;
+      } catch (error: any) {
+        if (error?.error === 'login_required' || error?.error === 'consent_required') {
+          return loginWithRedirect({
+            authorizationParams: {
+              organization: organization || undefined,
+              invitation: invitation || undefined,
+            },
+          });
+        }
+
+        handleError(error);
+      }
+    },
+    [handleError, invitation, loginWithRedirect, organization]
+  );
 
   useEffect(() => {
     const searchParams = new URL(window.location.href).searchParams;
@@ -230,7 +252,7 @@ const AuthenticationProvider: React.FC = ({ children }) => {
 
       if (error === 'access_denied') {
         const org = organizations[0];
-        setSelectedOrganization(org);
+        setSelectedOrganization(org.org_id);
         loginWithRedirect({
           authorizationParams: {
             organization: org?.org_id || undefined,
@@ -248,6 +270,22 @@ const AuthenticationProvider: React.FC = ({ children }) => {
     }
   }, [auth0Client, isLoading, isAuthenticated]);
 
+  const switchOrganization = useCallback(
+    async function (orgID) {
+      const client = await getAuth0Client();
+      await client.logout({ openUrl: false });
+      await client.loginWithRedirect({
+        authorizationParams: {
+          organization: orgID,
+        },
+      });
+      setSelectedOrganization(orgID);
+    },
+    [setSelectedOrganization]
+  );
+
+  const orfiumProducts = useOrfiumProducts(selectedOrganization?.org_id);
+
   return (
     <AuthenticationContext.Provider
       value={{
@@ -256,6 +294,10 @@ const AuthenticationProvider: React.FC = ({ children }) => {
         loginWithRedirect,
         logout: logoutAuth,
         getAccessTokenSilently: (o?: GetTokenSilentlyOptions) => getAccessTokenSilently(o),
+        orfiumProducts,
+        organizations,
+        selectedOrganization,
+        switchOrganization,
         user,
       }}
     >

--- a/src/hooks/useOrfiumProducts/index.ts
+++ b/src/hooks/useOrfiumProducts/index.ts
@@ -1,0 +1,23 @@
+// import { useQuery } from 'react-query';
+import { useEffect, useState } from 'react';
+import { orfiumIdBaseInstance } from '../../request';
+import { Product } from './types';
+
+export function useOrfiumProducts(orgId: string | undefined) {
+  const [data, setData] = useState<Product[] | null>(null);
+
+  useEffect(() => {
+    const { request, cancelTokenSource } = orfiumIdBaseInstance.createRequest<Product[]>({
+      method: 'get',
+      url: '/products/',
+    });
+
+    request().then((resp) => {
+      setData(resp);
+    });
+
+    return cancelTokenSource.cancel;
+  }, [orgId]);
+
+  return data;
+}

--- a/src/hooks/useOrfiumProducts/types.ts
+++ b/src/hooks/useOrfiumProducts/types.ts
@@ -1,0 +1,14 @@
+export type ClientMetadata = {
+  product_code: string;
+};
+
+export type Product = {
+  client_id: string;
+  client_metadata: ClientMetadata;
+  grant_types: string | null;
+  icon_url: string;
+  login_url: string;
+  logo_url: string;
+  name: string;
+  organization_usage: string;
+};


### PR DESCRIPTION
Resolves [DSTRBTN-540]

Resolves [DSTRBTN-538]


<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the use of `QueryClient` and `QueryClientProvider` from the authentication context tests and the `useOrfiumProducts` hook. It also modifies the `Product` type and the way `orfiumProducts` is fetched and used.
> 
> ## What changed
> - Removed `QueryClient` and `QueryClientProvider` from authentication context tests.
> - Removed `QueryClient` from `useOrfiumProducts` hook and replaced it with `useState` and `useEffect`.
> - Modified the `Product` type to include `client_id`, `grant_types`, `icon_url`, and rearranged the order of properties.
> - Changed the way `orfiumProducts` is fetched and used in `AuthenticationProvider`.
> 
> ## How to test
> - Run the authentication context tests to ensure they still pass without the `QueryClient`.
> - Check the `useOrfiumProducts` hook to ensure it still fetches and returns data correctly.
> - Check the `AuthenticationProvider` to ensure `orfiumProducts` is used correctly.
> 
> ## Why make this change
> - The way `orfiumProducts` is fetched and used was changed to to resolve issues with using this component in applications with newer versions of `react-query`, since the renameing of the package to `@tanstack/react-query` causes resolution issues.
> - The `QueryClient` and `QueryClientProvider` were removed because they were not necessary for the tests or the `useOrfiumProducts` hook.
> - The `Product` type was modified to better reflect the data being fetched.
</details>

[DSTRBTN-540]: https://orfium.atlassian.net/browse/DSTRBTN-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSTRBTN-538]: https://orfium.atlassian.net/browse/DSTRBTN-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ