### PR TITLE
feat: Implement a navigational menu item

### DIFF
--- a/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/MenuItem.styles.ts
+++ b/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/MenuItem.styles.ts
@@ -1,0 +1,118 @@
+import { css, SerializedStyles } from '@emotion/react';
+import styled from '@emotion/styled';
+import { Theme } from '@orfium/ictinus';
+import { flexCenter, flexCenterVertical, transition } from '@orfium/ictinus/dist/theme/functions';
+import { getFocus } from '@orfium/ictinus/dist/theme/states';
+import { rem } from 'polished';
+import { NavLink, NavLinkProps } from 'react-router-dom';
+
+const itemStyle = (theme: Theme): SerializedStyles => css`
+  ${flexCenterVertical};
+  height: ${rem(44)};
+  color: ${theme.utils.getColor('darkGrey', 850)};
+  cursor: default;
+`;
+
+const menuItemStyle = (theme: Theme) => css`
+  ${itemStyle(theme)};
+  font-size: ${theme.typography.fontSizes['14']};
+  font-weight: ${theme.typography.weights.medium};
+  padding: 0 ${theme.spacing.sm};
+  border: 0 solid transparent;
+  display: flex;
+  justify-content: flex-start;
+  text-decoration: none;
+  border-radius: ${rem(4)};
+  transition: background-color 0.15s ease;
+  cursor: pointer;
+  background-color: transparent;
+  flex-shrink: 0;
+  color: ${theme.utils.getColor('lightGrey', 650)};
+
+  &.active {
+    background-color: ${theme.utils.getColor('lightGrey', 100)};
+    color: ${theme.utils.getColor('blue', 600)};
+  }
+
+  &:hover {
+    background-color: ${theme.utils.getColor('lightGrey', 100)};
+  }
+
+  &:focus-visible {
+    outline: ${getFocus({ theme }).styleOutline};
+  }
+`;
+
+export const MenuItemButton = styled.button`
+  ${({ theme }) => menuItemStyle(theme)};
+  width: 100%;
+`;
+
+export const MenuItemText = styled.span<{ color: string }>`
+  color: ${({ color }) => color};
+  transform: scale(1);
+  transition: transform 0.15s ease;
+`;
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export const MenuLink = styled<NavLinkProps & { isSubMenu: boolean }>(NavLink)`
+  ${
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ({ theme, isSubMenu }) => menuItemStyle(theme, isSubMenu)
+  };
+  text-decoration: none;
+
+  &:active {
+    > span {
+      transform: scale(0.95);
+    }
+  }
+`;
+
+export const ArrowContainer = styled.div<{ open: boolean }>`
+  ${transition(0.2)};
+  ${flexCenter};
+  width: ${rem(24)};
+  height: ${rem(24)};
+  margin-left: auto;
+  position: relative;
+
+  path {
+    background-color: ${({ theme }) => theme.utils.getColor('lightGrey', 750)};
+  }
+`;
+
+export const MenuIcon = styled.div<{ hidden: boolean }>`
+  position: relative;
+  ${transition(0.2)};
+  ${flexCenter};
+  margin-right: ${({ theme }) => theme.spacing.sm};
+  width: ${rem(32)};
+  height: ${rem(32)};
+  border-radius: 50%;
+  flex-shrink: 0;
+  opacity: ${({ hidden }) => (hidden ? 0 : 1)};
+  visibility: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+  transform: ${({ hidden }) => (hidden ? `scale(0.6)` : `scale(1)`)};
+`;
+
+export const ExpandCollapseWrapper = styled.div<{ matched: boolean }>`
+  transition: background-color 0.15s ease;
+  background-color: ${({ theme, matched }) =>
+    matched ? theme.utils.getColor('darkBlue', null, 'pale') : 'transparent'};
+  border-radius: ${rem(4)};
+
+  > div > button + div {
+    overflow: hidden;
+  }
+`;
+
+export const Bullet = styled.span<{ color: string }>`
+  border-radius: 100%;
+  width: ${rem(7)};
+  height: ${rem(7)};
+  background-color: ${({ color }) => color};
+  transition: background-color 0.15s ease;
+`;

--- a/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/MenuItem.tsx
+++ b/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/MenuItem.tsx
@@ -1,0 +1,136 @@
+import { ExpandCollapse, Icon, useTheme, useTypeColorToColorMatch } from '@orfium/ictinus';
+import { BASE_SHADE } from '@orfium/ictinus/dist/theme/palette';
+import React from 'react';
+import { useLocation, useRouteMatch } from 'react-router-dom';
+import FlippableArrow from '../../../../../../FlippableArrow';
+import { MenuItem as MenuItemType } from '../../../../../types';
+import {
+  ArrowContainer,
+  Bullet,
+  ExpandCollapseWrapper,
+  MenuIcon,
+  MenuItemButton,
+  MenuItemText,
+  MenuLink,
+} from './MenuItem.styles';
+
+type Props = {
+  /** Defines if the menu item is expanded */
+  expanded: boolean;
+  toggleMenuItem: (newUrl: string) => void;
+  item: MenuItemType;
+};
+
+function MenuItemContent(props: { expanded: boolean; item: MenuItemType; isSubMenu?: boolean }) {
+  const { item, expanded, isSubMenu = false } = props;
+  const match = useRouteMatch(item.url);
+  const theme = useTheme();
+  const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
+  const { shade } = calculateColorBetweenColorAndType('', 'primary');
+
+  const isCurrent = !!match;
+  const hasSubMenus = item.options.length > 0;
+  const color = isCurrent
+    ? theme.utils.getColor('blue', 600)
+    : theme.utils.getColor('lightGrey', 650);
+
+  return (
+    <React.Fragment>
+      <MenuIcon hidden={isSubMenu ? (isCurrent ? false : true) : false}>
+        {isSubMenu ? (
+          <Bullet color={color} />
+        ) : (
+          <Icon
+            name={item.iconName}
+            color={color}
+            size={16}
+            variant={isCurrent ? shade : BASE_SHADE}
+          />
+        )}
+      </MenuIcon>
+      <MenuItemText color={color} className={'menu-item-text'}>
+        {item.name}
+      </MenuItemText>
+      {hasSubMenus ? (
+        <ArrowContainer open={expanded}>
+          <FlippableArrow expanded={expanded} color={color} size={10} />
+        </ArrowContainer>
+      ) : null}
+    </React.Fragment>
+  );
+}
+
+const MenuItem: React.FC<Props> = ({ expanded, toggleMenuItem, item }) => {
+  const match = useRouteMatch(item.url);
+  const { state } = useLocation<{
+    previous: {
+      pathname: string;
+      search: string;
+    };
+  } | null>();
+
+  const hasSubMenus = item.options.length > 0;
+
+  return (
+    <React.Fragment>
+      {hasSubMenus ? (
+        <ExpandCollapseWrapper matched={!!match}>
+          <ExpandCollapse
+            expanded={expanded}
+            onChange={() => toggleMenuItem(item.url)}
+            textAndControl={(handleClick) => {
+              return (
+                <MenuItemButton type={'button'} data-testid={item.url} onClick={handleClick}>
+                  <MenuItemContent expanded={expanded} item={item} />
+                </MenuItemButton>
+              );
+            }}
+          >
+            {() => {
+              return (
+                <React.Fragment>
+                  {item.options.map(
+                    (subMenuItem) =>
+                      subMenuItem.visible && (
+                        <MenuLink
+                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                          // @ts-ignore
+                          exact
+                          to={{
+                            pathname: subMenuItem.url,
+                            state,
+                          }}
+                          data-testid={subMenuItem.url}
+                          key={subMenuItem.url}
+                          id={'submenu-item-link'}
+                          isSubmenu
+                        >
+                          <MenuItemContent expanded={expanded} item={subMenuItem} isSubMenu />
+                        </MenuLink>
+                      )
+                  )}
+                </React.Fragment>
+              );
+            }}
+          </ExpandCollapse>
+        </ExpandCollapseWrapper>
+      ) : (
+        <MenuLink
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          exact
+          to={{
+            pathname: item.url,
+            state,
+          }}
+          data-testid={item.url}
+          key={item.url}
+        >
+          <MenuItemContent expanded={expanded} item={item} />
+        </MenuLink>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default MenuItem;

--- a/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/index.ts
+++ b/src/ui/Navigation/components/Drawer/Navigation/components/MenuItem/index.ts
@@ -1,0 +1,2 @@
+export * from './MenuItem';
+export { default } from './MenuItem';


### PR DESCRIPTION
Resolves [DSTRBTN-540]

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new `MenuItem` component for the navigation drawer. The component includes styles and functionality for handling menu items with and without submenus.
> 
> ## What changed
> Three new files were added:
> 
> 1. `MenuItem.styles.ts`: This file contains all the styled components and CSS for the `MenuItem` component.
> 2. `MenuItem.tsx`: This is the main `MenuItem` component file. It handles the rendering of menu items and their submenus, and includes functionality for expanding and collapsing submenus.
> 3. `index.ts`: This file exports the `MenuItem` component.
> 
> ## How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this pull request.
> 2. Start the application.
> 3. Navigate to the drawer navigation.
> 4. Click on a menu item. If it has a submenu, it should expand to show the submenu items.
> 5. Click on a submenu item. It should navigate to the corresponding page.
> 
> ## Why make this change
> This change was made to improve the navigation drawer's functionality and user experience. With this change, users can easily navigate to different pages in the application, and submenus provide a way to organize related pages under a single menu item.
</details>

[DSTRBTN-540]: https://orfium.atlassian.net/browse/DSTRBTN-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ