### PR TITLE
[DVP-207] feat: add fresh=true to request fresh membership

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "@auth0/auth0-spa-js": "^2.1.2",
     "axios": "^0.21.4",
     "axios-mock-adapter": "^1.19.0",
+    "dayjs": "^1.11.10",
     "jwt-decode": "^3.1.2",
     "react-error-boundary": "^3.1.4",
-    "zustand": "^4.0.0-rc.1",
-    "react-router-dom": "^5.3.1"
+    "react-router-dom": "^5.3.1",
+    "zustand": "^4.0.0-rc.1"
   },
   "devDependencies": {
     "@amanda-mitchell/semantic-release-npm-multiple": "^3.5.0",

--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 import React, { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+import dayjs from 'dayjs';
 import { orfiumIdBaseInstance } from '../request';
 import useOrganization, { Organization } from '../store/useOrganization';
 import { Box, LoadingContent, Wrapper } from './Authentication.style';
@@ -43,7 +44,7 @@ Authentication.TopBar = TopBar;
  * This is the main component that is wrapped on the authentication.
  */
 const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
-  const { isLoading, isAuthenticated, getAccessTokenSilently, logout, loginWithRedirect } =
+  const { isLoading, isAuthenticated, getAccessTokenSilently, logout, loginWithRedirect, user } =
     useAuthentication();
   const { organizations, setOrganizations, setSelectedOrganization, selectedOrganization } =
     useOrganization();
@@ -66,7 +67,10 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
         const requestInstance = orfiumIdBaseInstance.createRequest<Organization[]>({
           method: 'get',
           url: '/memberships/',
-          params: config.productCode ? { product_code: config.productCode } : undefined,
+          params: {
+            ...(config.productCode ? { product_code: config.productCode } : {}),
+            fresh: dayjs(user?.updated_at).isAfter(dayjs().subtract(1, 'minute')) || undefined,
+          },
         });
         const data = await requestInstance.request();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,6 +3786,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.11.10:
+  version "1.11.10"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
+
 dayjs@^1.8.34:
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"


### PR DESCRIPTION
## Description

As a user when I get invited to an organisation and accept my invitation I should see an up to date memberships response.

Right now the response is cached and it’s invalidation may take 5-10 seconds leading to a broken experience. This leads the facade to return the previous response, if any, without the new organization from the invite.

On invitations, toolbox could send a parameter to sso-facade, say fresh=true on GET /memberships expecting a "fresh" version of the response. SSO-Facade should not fetch results from the cache (Dynamo). It should instead fetch the results directly from Auth0.

[https://orfium.atlassian.net/browse/DVP-207](https://orfium.atlassian.net/browse/DVP-207)

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

Tested on orfium one locally with invitation from auth0
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
