### PR TITLE
[DVP-227] feat: update the way we architecture to avoid unpredictable states

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
   },
   "rules": {
     /* React rules */
+    "react/react-in-jsx-scope": "off",
     "react/no-direct-mutation-state": "error",
     "react/no-unused-prop-types": "warn",
     "react/self-closing-comp": [

--- a/__mocks__/@auth0/auth0-spa-js.ts
+++ b/__mocks__/@auth0/auth0-spa-js.ts
@@ -38,57 +38,55 @@ export const handleRedirectCallback = jest.fn(() => {
 export const isAuthenticated = jest.fn();
 export const logout = jest.fn();
 export const loginWithPopup = jest.fn();
-export const createAuth0Client = jest.fn().mockImplementation((options: any) =>
-  Promise.resolve({
-    getTokenSilently,
-    loginWithRedirect,
-    loginWithPopup,
-    getUser,
-    logout,
-    handleRedirectCallback,
-    isAuthenticated,
-    options: {
-      ...options,
-      onRedirectCallback,
-    },
-    cacheLocation: 'localstorage',
-    httpTimeoutMs: 10000,
-    cookieStorage: {
+export const Auth0Client = jest.fn().mockImplementation((options: any) => ({
+  getTokenSilently,
+  loginWithRedirect,
+  loginWithPopup,
+  getUser,
+  logout,
+  handleRedirectCallback,
+  isAuthenticated,
+  options: {
+    ...options,
+    onRedirectCallback,
+  },
+  cacheLocation: 'localstorage',
+  httpTimeoutMs: 10000,
+  cookieStorage: {
+    get: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  },
+  orgHintCookieName: 'auth0..organization_hint',
+  isAuthenticatedCookieName: 'auth0..is.authenticated',
+  sessionCheckExpiryDays: 1,
+  scope: 'offline_access',
+  transactionManager: {
+    storage: {
       get: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
     },
-    orgHintCookieName: 'auth0..organization_hint',
-    isAuthenticatedCookieName: 'auth0..is.authenticated',
-    sessionCheckExpiryDays: 1,
-    scope: 'offline_access',
-    transactionManager: {
-      storage: {
-        get: jest.fn(),
-        save: jest.fn(),
-        remove: jest.fn(),
-      },
-      clientId: '',
-      storageKey: 'a0.spajs.txs.',
-      transaction: null,
-    },
+    clientId: '',
+    storageKey: 'a0.spajs.txs.',
+    transaction: null,
+  },
+  nowProvider: jest.fn(),
+  cacheManager: {
+    cache: {},
+    keyManifest: null,
     nowProvider: jest.fn(),
-    cacheManager: {
-      cache: {},
-      keyManifest: null,
-      nowProvider: jest.fn(),
-    },
-    domainUrl: 'https://',
-    tokenIssuer: 'https:///',
-    defaultScope: 'openid profile email',
-    customOptions: {
-      onRedirectCallback,
-      organization: undefined,
-    },
-    useRefreshTokensFallback: true,
-    useRefreshTokens: true,
-  })
-);
+  },
+  domainUrl: 'https://',
+  tokenIssuer: 'https:///',
+  defaultScope: 'openid profile email',
+  customOptions: {
+    onRedirectCallback,
+    organization: undefined,
+  },
+  useRefreshTokensFallback: true,
+  useRefreshTokens: true,
+}));
 
 /*
  * Mock auth0 client with predefined values

--- a/src/authentication/Authentication.tsx
+++ b/src/authentication/Authentication.tsx
@@ -1,6 +1,6 @@
 import { Button, Loader, ThemeProvider } from '@orfium/ictinus';
 import * as Sentry from '@sentry/browser';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import dayjs from 'dayjs';
@@ -48,7 +48,6 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
     useAuthentication();
   const { organizations, setOrganizations, setSelectedOrganization, selectedOrganization } =
     useOrganization();
-  const [systemLoading, setSystemLoading] = useState<boolean | undefined>(undefined);
 
   /**
    * On initial load the useEffect checks if there are no loading at all and if both are false will try to get a valid token with organization
@@ -58,8 +57,7 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
    * - in case of no organization id pass the first fetched organization from the above list and re-fetch a token
    */
   useEffect(() => {
-    if (!systemLoading && !isLoading) {
-      setSystemLoading(true);
+    if (!isLoading && user?.updated_at) {
       (async () => {
         // moving this will affect the app. If this is moved below when clearing the storage the app constantly refresh
         const response = await getAccessTokenSilently();
@@ -75,32 +73,35 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
         const data = await requestInstance.request();
 
         setOrganizations(data);
-        if (!selectedOrganization?.org_id && data?.length > 0) {
-          setSelectedOrganization(data[0]);
+        if (response?.decodedToken?.org_id) {
+          const orgData = data.find((org) => org.org_id === response.decodedToken.org_id);
+          setSelectedOrganization(orgData || data[0]);
         }
         // if token doesn't have an organization and the user has available organizations
         // set continue and set one
-        if (!response?.decodedToken?.org_id && data?.length) {
+        else if (!response?.decodedToken?.org_id && data?.length) {
           // IMPORTANT - when we are using `useRefreshTokens` and `cacheLocation` on Auth0 we can fetch just a token with organization through `getTokenSilently`
           // we must use loginWithRedirect in that case thus this is happening here
           // https://auth0.com/docs/secure/tokens/refresh-tokens/use-refresh-token-rotation
           await loginWithRedirect({
             authorizationParams: {
-              organization: selectedOrganization?.org_id || data[0].org_id,
+              organization: data[0].org_id,
             },
           });
-        } else {
-          // set false at all times
-          setSystemLoading(false);
         }
       })();
     }
-    // @NOTE selectedOrganization?.org_id, isLoading, systemLoading
-    // are missing on purpose from the deps as these are being updated from places where the organization id is being handled with refresh from auth0
-  }, [getAccessTokenSilently, loginWithRedirect, setOrganizations, setSelectedOrganization]);
+  }, [
+    getAccessTokenSilently,
+    isLoading,
+    loginWithRedirect,
+    setOrganizations,
+    setSelectedOrganization,
+    user?.updated_at,
+  ]);
 
   // when loading is true before navigation this is not showing anymore
-  if (systemLoading === undefined || systemLoading || isLoading || !isAuthenticated) {
+  if (selectedOrganization === null || isLoading || !isAuthenticated) {
     return (
       <Wrapper data-testid={'orfium-auth-loading'}>
         <LoadingContent>
@@ -110,7 +111,7 @@ const AuthenticationWrapper: React.FunctionComponent = ({ children }) => {
     );
   }
 
-  if (organizations.length === 0) {
+  if (organizations?.length === 0) {
     return (
       <ThemeProvider>
         <Wrapper data-testid={'orfium-no-organizations'}>

--- a/src/authentication/authentication.test.tsx
+++ b/src/authentication/authentication.test.tsx
@@ -1,12 +1,11 @@
 import { cleanup, render, waitFor } from '@testing-library/react';
-import React from 'react';
 
 import {
   getNewFakeToken,
   getTokenSilently,
+  getUser,
   isAuthenticated,
   loginWithRedirect,
-  // @ts-ignore
 } from '../../__mocks__/@auth0/auth0-spa-js';
 import { orfiumIdBaseInstance } from '../request';
 import MockRequest from '../request/mock';
@@ -38,7 +37,17 @@ describe('Authentication: ', () => {
 
   it('renders the test component', async () => {
     getTokenSilently.mockResolvedValue(getNewFakeToken());
+    jest.mock('../store/useUser', () => ({
+      __esModule: true,
+      default: {
+        user: {},
+      },
+    }));
     isAuthenticated.mockResolvedValue(true);
+    getUser.mockResolvedValue({
+      name: 'John Doe',
+      updated_at: new Date().toDateString(),
+    });
     mock.onGet('/memberships/').reply(200, [{ org_id: 'a' }]);
 
     const { findByTestId } = render(
@@ -49,7 +58,11 @@ describe('Authentication: ', () => {
 
     expect(await findByTestId('orfium-auth-loading')).toBeTruthy();
 
-    expect(await findByTestId('test')).toBeTruthy();
+    expect(
+      await findByTestId('test', undefined, {
+        timeout: 3000,
+      })
+    ).toBeTruthy();
   });
 
   it('redirects to login if not authenticated', async () => {
@@ -69,6 +82,10 @@ describe('Authentication: ', () => {
   it('renders the loading while its authenticating', async () => {
     getTokenSilently.mockResolvedValue(getNewFakeToken());
     isAuthenticated.mockResolvedValue(true);
+    getUser.mockResolvedValue({
+      name: 'John Doe',
+      updated_at: new Date().toDateString(),
+    });
     const { findByTestId } = render(
       <AuthenticationProvider>
         <TestComp />
@@ -80,6 +97,10 @@ describe('Authentication: ', () => {
   it('renders the no organization message when it should', async () => {
     getTokenSilently.mockResolvedValue(getNewFakeToken());
     isAuthenticated.mockResolvedValue(true);
+    getUser.mockResolvedValue({
+      name: 'John Doe',
+      updated_at: new Date().toDateString(),
+    });
     mock.onGet('/memberships/').replyOnce(200, []);
 
     const { findByTestId } = render(
@@ -89,6 +110,10 @@ describe('Authentication: ', () => {
     );
 
     expect(await findByTestId('orfium-auth-loading')).toBeTruthy();
-    expect(await findByTestId('orfium-no-organizations')).toBeTruthy();
+    expect(
+      await findByTestId('orfium-no-organizations', undefined, {
+        timeout: 13000,
+      })
+    ).toBeTruthy();
   });
 });

--- a/src/authentication/components/TopBar/TopBar.test.tsx
+++ b/src/authentication/components/TopBar/TopBar.test.tsx
@@ -1,9 +1,12 @@
 import { ThemeProvider } from '@orfium/ictinus';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import React from 'react';
 
 // @ts-ignore
-import { createAuth0Client as mockedCreateAuth0 } from '../../../../__mocks__/@auth0/auth0-spa-js';
+import {
+  Auth0Client as mockedCreateAuth0,
+  loginWithRedirect,
+  logout,
+} from '../../../../__mocks__/@auth0/auth0-spa-js';
 import { Organization } from '../../../store/useOrganization';
 import { Authentication } from '../../index';
 const mockOrganizations: Organization[] = [
@@ -46,12 +49,14 @@ const mockedUserFn = jest
   .mockReturnValue(mockedUser);
 const mockSetSelectedOrganization = jest.fn();
 const mockLogout = jest.fn();
+const mockResetOrganization = jest.fn();
 
 jest.mock('../../../store/useOrganization', () =>
   jest.fn(() => ({
     organizations: mockOrganizations,
     setSelectedOrganization: mockSetSelectedOrganization,
     selectedOrganization: mockOrganizations[0],
+    reset: mockResetOrganization,
   }))
 );
 
@@ -88,7 +93,9 @@ describe('TopBar', () => {
     fireEvent.click(getByText(mockOrganizations[0].display_name));
     fireEvent.click(getByTestId('ictinus_list_item_0'));
 
-    await waitFor(() => expect(mockSetSelectedOrganization).toBeCalledTimes(1));
+    await waitFor(() => expect(logout).toBeCalledTimes(1));
+    await waitFor(() => expect(loginWithRedirect).toBeCalledTimes(1));
+    await waitFor(() => expect(mockResetOrganization).toBeCalledTimes(1));
   });
 
   describe('user data', function () {
@@ -125,6 +132,7 @@ describe('TopBar', () => {
       </ThemeProvider>
     );
 
+    // @ts-ignore
     const userMenu = getByTestId('userMenu')?.firstChild;
     userMenu && fireEvent.click(userMenu);
     fireEvent.click(getByText('Logout'));

--- a/src/authentication/components/TopBar/TopBar.tsx
+++ b/src/authentication/components/TopBar/TopBar.tsx
@@ -17,7 +17,7 @@ export type TopBarProps = {
 export const TopBar: React.FC<TopBarProps> = memo(
   ({ logoIcon, onMenuIconClick, additionalTools }) => {
     const { user, logout } = useAuthentication();
-    const { organizations, setSelectedOrganization, selectedOrganization } = useOrganization();
+    const { organizations, selectedOrganization, reset } = useOrganization();
 
     const userConfig = {
       items: ['Logout'],
@@ -50,21 +50,21 @@ export const TopBar: React.FC<TopBarProps> = memo(
               dataTestId={'organization-picker'}
               color={'lightGrey-50'}
               onSelect={async (option: string) => {
-                const foundOrg = organizations.find((org) => org.display_name === option);
+                const foundOrg = organizations?.find((org) => org.display_name === option);
                 if (foundOrg) {
-                  const client = await getAuth0Client();
+                  const client = getAuth0Client();
                   await client.logout({ openUrl: false });
                   await client.loginWithRedirect({
                     authorizationParams: {
                       organization: foundOrg.org_id,
                     },
                   });
-                  setSelectedOrganization(foundOrg);
+                  reset();
                 }
               }}
               buttonText={selectedOrganization?.display_name}
               items={organizations
-                .filter((org) => org.display_name !== selectedOrganization?.display_name)
+                ?.filter((org) => org.display_name !== selectedOrganization?.display_name)
                 .map((org) => org.display_name)}
             />
           </div>

--- a/src/authentication/context.tsx
+++ b/src/authentication/context.tsx
@@ -98,9 +98,7 @@ export const logoutAuth = async ({ force = false }: { force?: boolean } = {}) =>
       });
     }
   } catch (e: unknown) {
-    if (e) {
-      throw e;
-    }
+    throw e;
   }
 };
 

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -46,7 +46,7 @@ export type AuthenticationContextProps = {
   isAuthenticated: boolean;
   isLoading: boolean;
   loginWithRedirect(o?: RedirectLoginOptions): Promise<void>;
-  logout: () => void;
+  logout: (props?: { force?: boolean }) => void;
   getAccessTokenSilently: (opts?: GetTokenSilentlyOptions) => Promise<{
     token: string;
     decodedToken: DecodedTokenResponse | Record<string, never>;

--- a/src/request/request.test.ts
+++ b/src/request/request.test.ts
@@ -1,10 +1,8 @@
 import { cleanup } from '@testing-library/react';
 import { AxiosInstance } from 'axios';
 
-// @ts-ignore
 import { FAKE_TOKEN, getTokenSilently } from '../../__mocks__/@auth0/auth0-spa-js';
-import { CreateAPIInstanceType, METHODS } from './index';
-import { createAPIInstance } from './index';
+import { createAPIInstance, CreateAPIInstanceType, METHODS } from './index';
 import MockRequest from './mock';
 
 describe('Request: ', () => {

--- a/src/store/useOrganization.ts
+++ b/src/store/useOrganization.ts
@@ -17,17 +17,17 @@ export type Organization = {
 
 type Store = {
   // list of organizations that fetched and stored
-  organizations: Organization[];
+  organizations: Organization[] | null;
   // the selected organization for the current session
-  selectedOrganization: Organization | undefined;
+  selectedOrganization: Organization | undefined | null;
   setOrganizations: (organizations: Organization[]) => void;
   setSelectedOrganization: (organizations: Organization) => void;
   reset: () => void;
 };
 
 const initialState = {
-  organizations: [],
-  selectedOrganization: undefined,
+  organizations: null,
+  selectedOrganization: null,
 };
 const useOrganization = create(
   persist<Store>(

--- a/src/store/useUser.ts
+++ b/src/store/useUser.ts
@@ -1,0 +1,21 @@
+import create from 'zustand';
+import { User } from '../authentication';
+
+type Store = {
+  user?: User;
+  setUser: (user: User | undefined) => void;
+  reset: () => void;
+};
+
+const initialState = {
+  user: undefined,
+};
+const useUser = create<Store>()((set, __get) => ({
+  ...initialState,
+  setUser: (user: User | undefined) => set(() => ({ user })),
+  reset: () => {
+    set({ ...initialState });
+  },
+}));
+
+export default useUser;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,7 @@
     "outDir": "dist",
     "module": "esnext",
     "target": "es5",
-    "lib": [
-      "es5",
-      "es6",
-      "es7",
-      "es2017",
-      "dom"
-    ],
+    "lib": ["dom", "es5", "es6", "es7", "es2017"],
     "sourceMap": true,
     "skipLibCheck": true,
     "allowJs": true,
@@ -17,7 +11,6 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "strict": true,
-    "rootDir": "./src",
     "baseUrl": "./src",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
@@ -29,18 +22,11 @@
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "types": [
-      "node",
-      "jest",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["node", "jest", "@testing-library/jest-dom"],
     "jsxImportSource": "react",
-    "declarationDir": "./dist/types",
+    "declarationDir": "./dist/types"
   },
-  "include": [
-    "./src/*",
-    "./src/**/*"
-  ],
+  "include": ["./src/*", "./src/**/*"],
   "exclude": [
     "**/node_modules/**/",
     "node_modules",


### PR DESCRIPTION
## Description

This PR focuses on solve a specific issue where we had unexpected behaviour on SPA applications.
We noticed that we had unpredicted refreshes on our logic that was causing the `membership` API call to be triggered multiple times. Furthermore, other functionalities like logout was causing the same unexpected behaviour causing even Auth0 to throw `white` pages.

This PR solves:
* Loading state with change on organization store by introducing `null` value for initial state
* Logout to handle two cases with Auth0 logout and complete reset 
* Fetch membership based on user data. Previously we though Auth0 was handling that.
* Handle `User` data with a store for sharing it
* In errors try to `logout` the user from the current organization except expirations

The above steps lead us to have only the minimum calls to the `membership` API and to achieve a predictable flow with handling those two states, ours and auth0.

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
